### PR TITLE
Enhance Conduit page commands

### DIFF
--- a/Abies.Conduit/Page/Article.cs
+++ b/Abies.Conduit/Page/Article.cs
@@ -2,6 +2,7 @@ using Abies.Conduit.Main;
 using Abies.Conduit.Routing;
 using Abies.DOM;
 using System.Collections.Generic;
+using Abies.Conduit;
 using static Abies.Html.Attributes;
 using static Abies.Html.Events;
 
@@ -77,7 +78,7 @@ public class Page : Element<Model, Message>
             ),
             Message.SubmitComment => (
                 model with { SubmittingComment = true },
-                []
+                [ new SubmitCommentCommand(model.Slug.Value, model.CommentInput) ]
             ),
             Message.CommentSubmitted commentSubmitted => (
                 model with 
@@ -90,13 +91,28 @@ public class Page : Element<Model, Message>
                 },
                 []
             ),
-            Message.DeleteComment => (model, []),
+            Message.DeleteComment delete => (
+                model,
+                [ new DeleteCommentCommand(model.Slug.Value, delete.Id) ]
+            ),
             Message.CommentDeleted commentDeleted => (
-                model with 
-                { 
+                model with
+                {
                     Comments = model.Comments?.FindAll(c => c.Id != commentDeleted.Id)
                 },
                 []
+            ),
+            Message.ToggleFavorite => (
+                model,
+                model.Article != null ? [ new ToggleFavoriteCommand(model.Article.Slug, model.Article.Favorited) ] : []
+            ),
+            Message.ToggleFollow => (
+                model,
+                model.Article != null ? [ new ToggleFollowCommand(model.Article.Author.Username, model.Article.Author.Following) ] : []
+            ),
+            Message.DeleteArticle => (
+                model,
+                model.Article != null ? [ new DeleteArticleCommand(model.Article.Slug) ] : []
             ),
             _ => (model, [])
         };

--- a/Abies.Conduit/Page/Editor.cs
+++ b/Abies.Conduit/Page/Editor.cs
@@ -2,6 +2,7 @@ using Abies.Conduit.Main;
 using Abies.Conduit.Routing;
 using Abies.DOM;
 using System.Collections.Generic;
+using Abies.Conduit;
 using static Abies.Html.Attributes;
 using static Abies.Html.Events;
 
@@ -83,7 +84,9 @@ public class Page : Element<Model, Message>
             ),
             Message.ArticleSubmitted => (
                 model with { IsSubmitting = true, Errors = null },
-                []
+                model.Slug == null
+                    ? [ new CreateArticleCommand(model.Title, model.Description, model.Body, model.TagList ?? new List<string>()) ]
+                    : [ new UpdateArticleCommand(model.Slug, model.Title, model.Description, model.Body) ]
             ),
             Message.ArticleSubmitSuccess slug => (
                 model with { IsSubmitting = false, Errors = null, Slug = slug.Slug },

--- a/Abies.Conduit/Page/Profile.cs
+++ b/Abies.Conduit/Page/Profile.cs
@@ -76,7 +76,10 @@ public class Page : Element<Model, Message>
                     ? [new LoadArticlesCommand(favoritedBy: model.UserName.Value)]
                     : [new LoadArticlesCommand(author: model.UserName.Value)]
             ),
-            Message.ToggleFollow => (model, []),
+            Message.ToggleFollow => (
+                model,
+                model.Profile != null ? [ new ToggleFollowCommand(model.UserName.Value, model.Profile.Following) ] : []
+            ),
             _ => (model, [])
         };
 


### PR DESCRIPTION
## Summary
- wire up command dispatch in the Editor page when submitting articles
- run comment, follow and favorite commands from Article page
- add follow toggle command on Profile page

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406868c870832ea87256cd0032dc62