### PR TITLE
Fix DOM patch errors by preserving element ids

### DIFF
--- a/Abies/Types.cs
+++ b/Abies/Types.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
+using System.Threading;
 using Abies;
 using Abies.DOM;
 
@@ -164,6 +165,7 @@ namespace Abies
         private Node? _dom;
         // todo: clean up handlers when they are no longer needed
         private readonly ConcurrentDictionary<string, Message> _handlers = new();
+        private readonly SemaphoreSlim _dispatchLock = new(1, 1);
 
         public async Task Run(TArguments arguments)
         {
@@ -210,8 +212,44 @@ namespace Abies
             }
         }
 
+        private static Node PreserveIds(Node? oldNode, Node newNode)
+        {
+            if (oldNode is Element oldElement && newNode is Element newElement && oldElement.Tag == newElement.Tag)
+            {
+                var attrs = new Abies.DOM.Attribute[newElement.Attributes.Length];
+                for (int i = 0; i < newElement.Attributes.Length; i++)
+                {
+                    var attr = newElement.Attributes[i];
+                    attrs[i] = attr.Name == "id" ? attr with { Value = oldElement.Id } : attr;
+                }
+
+                var children = new Node[newElement.Children.Length];
+                for (int i = 0; i < newElement.Children.Length; i++)
+                {
+                    var oldChild = i < oldElement.Children.Length ? oldElement.Children[i] : null;
+                    children[i] = PreserveIds(oldChild, newElement.Children[i]);
+                }
+
+                return new Element(oldElement.Id, newElement.Tag, attrs, children);
+            }
+            else if (newNode is Element newElem)
+            {
+                var children = new Node[newElem.Children.Length];
+                for (int i = 0; i < newElem.Children.Length; i++)
+                {
+                    children[i] = PreserveIds(null, newElem.Children[i]);
+                }
+                return new Element(newElem.Id, newElem.Tag, newElem.Attributes, children);
+            }
+
+            return newNode;
+        }
+
         public async Task Dispatch(Message message)
         {
+            await _dispatchLock.WaitAsync();
+            try
+            {
             if (model is null)
             {
                 await Interop.WriteToConsole("Model not initialized");
@@ -232,8 +270,10 @@ namespace Abies
             // Generate new virtual DOM
             var newDocument = TApplication.View(newModel);
 
+            var alignedBody = PreserveIds(_dom, newDocument.Body);
+
             // Compute the patches
-            var patches = Operations.Diff(_dom, newDocument.Body);
+            var patches = Operations.Diff(_dom, alignedBody);
 
             // Apply patches and (de)register handlers
             foreach (var patch in patches)
@@ -257,14 +297,21 @@ namespace Abies
             }
 
             // Update the current virtual DOM
-            _dom = newDocument.Body;
+            _dom = alignedBody;
             await Interop.SetTitle(newDocument.Title);
 
             foreach (var command in commands)
             {
                 await HandleCommand(command);
             }
-        }        private static async Task HandleCommand(Command command)
+        }
+        finally
+        {
+            _dispatchLock.Release();
+        }
+    }
+
+        private static async Task HandleCommand(Command command)
         {
             switch(command)
             {                


### PR DESCRIPTION
## Summary
- keep DOM element ids consistent between renders
- align virtual DOM ids with previous DOM before diffing to avoid missing node errors

## Testing
- `dotnet test Abies.Tests/Abies.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684827d784a0832e8ed6e21312502309