### PR TITLE
fix: Use string comparison for gh-pages existence check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,7 +89,7 @@ jobs:
           auto-push: true
           save-data-file: true
           # Skip fetch on first run (creates branch if it doesn't exist)
-          skip-fetch-gh-pages: ${{ !steps.gh-pages-check.outputs.exists }}
+          skip-fetch-gh-pages: ${{ steps.gh-pages-check.outputs.exists != 'true' }}
           # Alert thresholds (for direct pushes to main)
           alert-threshold: '150%'
           comment-on-alert: true


### PR DESCRIPTION
## 📝 Description

### What
Fixed the GitHub Actions expression syntax for the `skip-fetch-gh-pages` parameter in the benchmark workflow.

### Why
The previous expression `${{ !steps.gh-pages-check.outputs.exists }}` doesn't work correctly in GitHub Actions because:
1. Step outputs are strings ("true" or "false"), not booleans
2. The `!` operator checks truthiness of the string, not its value
3. A non-empty string like "false" is truthy, so `!"false"` evaluates to `false`

This caused the workflow to attempt fetching the non-existent `gh-pages` branch, resulting in: `fatal: couldn't find remote ref gh-pages`

### How
Changed from boolean negation to explicit string comparison:
```yaml
# Before (broken)
skip-fetch-gh-pages: ${{ !steps.gh-pages-check.outputs.exists }}

# After (working)
skip-fetch-gh-pages: ${{ steps.gh-pages-check.outputs.exists != 'true' }}
```

When `exists` is `"false"`, the comparison `"false" != 'true'` evaluates to `true`, correctly skipping the fetch.

## ✅ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing
After merge, trigger workflow_dispatch on main. The workflow should:
1. Detect gh-pages doesn't exist → `exists=false`
2. Evaluate `"false" != 'true'` → `true` → skip fetch
3. Create gh-pages branch with baseline benchmark data

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [x] All commits follow Conventional Commits format
- [x] Branch is up-to-date with main
- [x] No merge conflicts