### PR TITLE
feat: Add ClearChildren optimization for bulk child removal

### DIFF
--- a/Abies.Presentation/wwwroot/abies.js
+++ b/Abies.Presentation/wwwroot/abies.js
@@ -970,6 +970,21 @@ setModuleImports('abies.js', {
     }),
 
     /**
+     * Clears all children from a parent element.
+     * This is more efficient than multiple removeChild calls when clearing all children.
+     * @param {string} parentId - The ID of the parent element to clear.
+     */
+    clearChildren: withSpan('clearChildren', async (parentId) => {
+        const parent = document.getElementById(parentId);
+        if (parent) {
+            // replaceChildren() with no args removes all children efficiently
+            parent.replaceChildren();
+        } else {
+            console.error(`Cannot clear children: parent with ID ${parentId} not found.`);
+        }
+    }),
+
+    /**
      * Replaces an existing node with new HTML content.
      * @param {number} oldNodeId - The ID of the node to replace.
      * @param {string} newHtml - The HTML string to replace with.
@@ -1157,6 +1172,14 @@ setModuleImports('abies.js', {
                     // Guard against child already removed or reparented
                     if (child && child.parentNode) {
                         child.remove();
+                    }
+                    break;
+                }
+                case 'ClearChildren': {
+                    const parent = document.getElementById(patch.ParentId);
+                    if (parent) {
+                        // replaceChildren() with no args efficiently removes all children
+                        parent.replaceChildren();
                     }
                     break;
                 }

--- a/Abies.SubscriptionsDemo/wwwroot/abies.js
+++ b/Abies.SubscriptionsDemo/wwwroot/abies.js
@@ -970,6 +970,21 @@ setModuleImports('abies.js', {
     }),
 
     /**
+     * Clears all children from a parent element.
+     * This is more efficient than multiple removeChild calls when clearing all children.
+     * @param {string} parentId - The ID of the parent element to clear.
+     */
+    clearChildren: withSpan('clearChildren', async (parentId) => {
+        const parent = document.getElementById(parentId);
+        if (parent) {
+            // replaceChildren() with no args removes all children efficiently
+            parent.replaceChildren();
+        } else {
+            console.error(`Cannot clear children: parent with ID ${parentId} not found.`);
+        }
+    }),
+
+    /**
      * Replaces an existing node with new HTML content.
      * @param {number} oldNodeId - The ID of the node to replace.
      * @param {string} newHtml - The HTML string to replace with.
@@ -1157,6 +1172,14 @@ setModuleImports('abies.js', {
                     // Guard against child already removed or reparented
                     if (child && child.parentNode) {
                         child.remove();
+                    }
+                    break;
+                }
+                case 'ClearChildren': {
+                    const parent = document.getElementById(patch.ParentId);
+                    if (parent) {
+                        // replaceChildren() with no args efficiently removes all children
+                        parent.replaceChildren();
                     }
                     break;
                 }

--- a/Abies/Interop.cs
+++ b/Abies/Interop.cs
@@ -56,6 +56,9 @@ public static partial class Interop
     [JSImport("removeChild", "abies.js")]
     public static partial Task RemoveChild(string parentId, string childId);
 
+    [JSImport("clearChildren", "abies.js")]
+    public static partial Task ClearChildren(string parentId);
+
     [JSImport("replaceChildHtml", "abies.js")]
     public static partial Task ReplaceChildHtml(string oldNodeId, string newHtml);
 

--- a/Abies/wwwroot/abies.js
+++ b/Abies/wwwroot/abies.js
@@ -970,6 +970,21 @@ setModuleImports('abies.js', {
     }),
 
     /**
+     * Clears all children from a parent element.
+     * This is more efficient than multiple removeChild calls when clearing all children.
+     * @param {string} parentId - The ID of the parent element to clear.
+     */
+    clearChildren: withSpan('clearChildren', async (parentId) => {
+        const parent = document.getElementById(parentId);
+        if (parent) {
+            // replaceChildren() with no args removes all children efficiently
+            parent.replaceChildren();
+        } else {
+            console.error(`Cannot clear children: parent with ID ${parentId} not found.`);
+        }
+    }),
+
+    /**
      * Replaces an existing node with new HTML content.
      * @param {number} oldNodeId - The ID of the node to replace.
      * @param {string} newHtml - The HTML string to replace with.
@@ -1157,6 +1172,14 @@ setModuleImports('abies.js', {
                     // Guard against child already removed or reparented
                     if (child && child.parentNode) {
                         child.remove();
+                    }
+                    break;
+                }
+                case 'ClearChildren': {
+                    const parent = document.getElementById(patch.ParentId);
+                    if (parent) {
+                        // replaceChildren() with no args efficiently removes all children
+                        parent.replaceChildren();
                     }
                     break;
                 }


### PR DESCRIPTION
## 📝 Description

### What
Add a new `ClearChildren` patch type that replaces N individual `RemoveChild` patches with a single DOM operation when clearing all children from an element.

### Why
The clear benchmark (09_clear1k) in js-framework-benchmark showed Abies was **3.58x slower** than Blazor WASM (159.6ms vs 44.6ms). When clearing 1000 rows, the framework was generating 1000 individual `RemoveChild` patches, each requiring:
- Patch record allocation
- PatchData JSON serialization
- Individual DOM `remove()` call

### How
- Detect when ALL children are being removed and none added in the diff algorithm
- Generate a single `ClearChildren` patch instead of N `RemoveChild` patches
- Use the native `parent.replaceChildren()` API which efficiently clears all children in one DOM operation

## 🔗 Related Issues

Related to performance optimization work tracking Abies vs Blazor benchmarks.

## ✅ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build/CI configuration change

## 🧪 Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

### Testing Details

- Added 4 new unit tests for ClearChildren behavior:
  - `ClearAllChildren_ShouldUseSingleClearChildrenPatch` - verifies single patch for complete clear
  - `ClearManyChildren_ShouldUseSingleClearChildrenPatch` - tests with 100 children
  - `RemoveSomeChildren_ShouldNotUseClearChildren` - ensures partial removals use RemoveChild
  - `ClearChildren_ShouldApplyCorrectly` - verifies patch application
- Ran js-framework-benchmark to measure improvement
- Verified swap benchmark (05_swap1k) shows no regression

## 📊 Benchmark Results

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| **09_clear1k** | 159.6ms | **91.2ms** | **1.75x faster (43% reduction)** |
| 05_swap1k | 121.6ms | 122.3ms | No regression ✓ |

### Comparison with Blazor

| Benchmark | Abies (New) | Blazor | Ratio |
|-----------|-------------|--------|-------|
| 09_clear1k | 91.2ms | 44.6ms | 2.0x slower (was 3.58x) |

## ✨ Changes Made

- Add `ClearChildren` patch struct in `Operations.cs`
- Add `ClearChildren` case to `Apply()` method
- Add `ClearChildren` case to `ApplyBatch()` pre-processing for handler cleanup
- Add `ClearChildren` case to `ConvertToPatchData()` for batch patching
- Add optimization in `DiffChildrenCore()` membership change path
- Add `ClearChildren` JSImport in `Interop.cs`
- Add `clearChildren` function in `abies.js`
- Add `ClearChildren` batch handler case in `abies.js`
- Add 4 unit tests in `DomBehaviorTests.cs`

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

None - this is a performance optimization with no API changes.

## 📋 Additional Context

This optimization is inspired by the approach used by other high-performance virtual DOM implementations. The key insight is that when clearing all children, a single `replaceChildren()` call is much faster than N individual `remove()` calls.

The optimization only triggers when:
1. ALL old children are being removed (`keysToRemove.Count == oldLength`)
2. NO new children are being added (`keysToAdd.Count == 0`)
3. NO children need to be diffed (`keysToDiff.Count == 0`)

This ensures we don't accidentally use the optimization when we should be doing fine-grained updates.

---

**Thank you for contributing to Abies! 🌲**