### PR TITLE
docs: Fix benchmark chart naming and add data migration script

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,10 +1,26 @@
-# Virtual DOM Benchmarks
+# Rendering Engine Benchmarks
 
-This document describes the benchmarking infrastructure for the Abies Virtual DOM diffing algorithm.
+This document describes the benchmarking infrastructure for the Abies rendering engine, including DOM diffing, HTML rendering, and event handler creation.
 
 ## Overview
 
 The Abies framework uses a Virtual DOM diffing algorithm to compute minimal patches between UI states. Performance of this algorithm is critical because it runs on every UI update.
+
+## Benchmark Categories
+
+The benchmark suite covers three categories:
+
+### DOM Diffing (`Abies.Benchmarks.Diffing/`)
+
+Measures the Virtual DOM diffing algorithm performance.
+
+### Rendering (`Abies.Benchmarks.Rendering/`)
+
+Measures HTML string rendering performance.
+
+### Event Handlers (`Abies.Benchmarks.Handlers/`)
+
+Measures event handler creation and registration performance.
 
 ## Benchmark Scenarios
 
@@ -110,11 +126,13 @@ public void YourNewBenchmark()
 
 ## Architecture
 
-```
+```text
 Abies.Benchmarks/
-├── DomDiffingBenchmarks.cs    # Virtual DOM benchmarks
+├── DomDiffingBenchmarks.cs    # Virtual DOM diffing benchmarks
+├── RenderingBenchmarks.cs     # HTML rendering benchmarks
+├── EventHandlerBenchmarks.cs  # Event handler creation benchmarks
 ├── UrlParsingBenchmarks.cs    # URL parsing benchmarks  
-├── Program.cs                  # Entry point
+├── Program.cs                 # Entry point
 └── Abies.Benchmarks.csproj    # Project file
 
 .github/workflows/

--- a/scripts/fix-benchmark-data.py
+++ b/scripts/fix-benchmark-data.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Fix benchmark data on gh-pages by merging old chart set names into new ones.
+
+Problem: The benchmark chart names were changed from:
+- "Virtual DOM Benchmarks" -> "Rendering Engine Throughput"
+- "Virtual DOM Allocations" -> "Rendering Engine Allocations"
+
+This resulted in two separate chart sets - the old ones stopped receiving updates.
+
+Solution: Merge the old entries into the new chart sets, sorted by date.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def fix_benchmark_data(input_file: str, output_file: str) -> None:
+    """Read the benchmark data, merge old names into new names, and write output."""
+    
+    # Read the data.js file
+    content = Path(input_file).read_text()
+    
+    # Remove the JavaScript wrapper
+    if content.startswith("window.BENCHMARK_DATA = "):
+        json_str = content.replace("window.BENCHMARK_DATA = ", "", 1)
+    else:
+        json_str = content
+    
+    data = json.loads(json_str)
+    
+    entries = data.get("entries", {})
+    
+    # Mapping of old names to new names
+    name_mapping = {
+        "Virtual DOM Benchmarks": "Rendering Engine Throughput",
+        "Virtual DOM Allocations": "Rendering Engine Allocations",
+    }
+    
+    # Merge old entries into new entries
+    for old_name, new_name in name_mapping.items():
+        if old_name in entries:
+            old_entries = entries[old_name]
+            
+            # Get or create the new entries list
+            if new_name not in entries:
+                entries[new_name] = []
+            
+            # Get existing commit IDs to avoid duplicates
+            existing_ids = {e["commit"]["id"] for e in entries[new_name] if "commit" in e and "id" in e["commit"]}
+            
+            # Add old entries that aren't duplicates
+            for entry in old_entries:
+                commit_id = entry.get("commit", {}).get("id", "")
+                if commit_id and commit_id not in existing_ids:
+                    entries[new_name].append(entry)
+                    existing_ids.add(commit_id)
+            
+            # Remove the old entry
+            del entries[old_name]
+            
+            print(f"Merged {len(old_entries)} entries from '{old_name}' into '{new_name}'")
+    
+    # Sort each entry list by date
+    for name in entries:
+        entries[name].sort(key=lambda e: e.get("date", 0))
+        print(f"'{name}': {len(entries[name])} total entries")
+    
+    data["entries"] = entries
+    
+    # Write the output with the JavaScript wrapper
+    # Use ensure_ascii=False to preserve ± symbols without escaping
+    output_content = "window.BENCHMARK_DATA = " + json.dumps(data, indent=2, ensure_ascii=False)
+    Path(output_file).write_text(output_content, encoding='utf-8')
+    
+    print(f"\nFixed data written to: {output_file}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <input_data.js> <output_data.js>")
+        print(f"Example: {sys.argv[0]} /tmp/benchmark-data.js /tmp/fixed-data.js")
+        sys.exit(1)
+    
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+    
+    fix_benchmark_data(input_file, output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📝 Description

### What
Fixes the benchmark chart naming mismatch on GitHub Pages and adds a utility script for future data migrations.

### Why
The benchmark chart names were changed in commit `7bd08a2` from:
- "Virtual DOM Benchmarks" → "Rendering Engine Throughput"
- "Virtual DOM Allocations" → "Rendering Engine Allocations"

This caused `github-action-benchmark` to create **new chart sets** while the old ones stopped receiving updates. The interactive charts at https://picea.github.io/Abies/dev/bench/ showed 4 separate charts (2 stale + 2 current) instead of 2 unified charts with complete history.

### How
1. **gh-pages fix** (already applied in commit `b3b8465`): Merged historical data from old chart sets into new ones using the fix script
2. **Documentation update**: Updated `docs/benchmarks.md` to reflect the new naming and benchmark categories
3. **Utility script**: Added `scripts/fix-benchmark-data.py` for future migrations

## 🔗 Related Issues
N/A - discovered during routine monitoring

## ✅ Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## 🧪 Testing
### Test Coverage
- [x] Verified gh-pages data.js shows merged chart sets (15 + 9 entries)
- [x] Verified raw data.js on GitHub shows only "Rendering Engine Throughput" and "Rendering Engine Allocations"

### Testing Details
- Fetched `https://raw.githubusercontent.com/Picea/Abies/gh-pages/dev/bench/data.js` and confirmed merge was successful
- GitHub Pages CDN may take a few minutes to refresh cached version

## ✨ Changes Made
- **`docs/benchmarks.md`**: Updated title from "Virtual DOM Benchmarks" to "Rendering Engine Benchmarks", added documentation for 3 benchmark categories (Diffing, Rendering, Handlers), updated Architecture section
- **`scripts/fix-benchmark-data.py`**: New utility script to merge benchmark chart data between name changes

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Documentation updated