### PR TITLE
ci: Add separate E2E memory benchmark chart

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -386,6 +386,7 @@ jobs:
           python3 scripts/convert-e2e-results.py \
             --results-dir ../js-framework-benchmark-fork/webdriver-ts/results \
             --output ./e2e-benchmark-results.json \
+            --output-memory ./e2e-benchmark-memory.json \
             --framework abies
 
       - name: Check if gh-pages exists
@@ -414,12 +415,29 @@ jobs:
           summary-always: true
           alert-comment-cc-users: '@MCGPPeters'
 
+      - name: Store E2E memory benchmark trends to gh-pages (main only)
+        uses: benchmark-action/github-action-benchmark@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gh-pages-check.outputs.exists == 'true'
+        with:
+          name: "1. E2E Benchmark: Memory (js-framework-benchmark)"
+          tool: customSmallerIsBetter
+          output-file-path: ./e2e-benchmark-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          save-data-file: true
+          alert-threshold: '120%'
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true
+          alert-comment-cc-users: '@MCGPPeters'
+
       - name: Copy results to workspace for upload
         if: always()
         run: |
           mkdir -p ./e2e-results
           cp -r ../js-framework-benchmark-fork/webdriver-ts/results/* ./e2e-results/ 2>/dev/null || true
           cp ./e2e-benchmark-results.json ./e2e-results/ 2>/dev/null || true
+          cp ./e2e-benchmark-memory.json ./e2e-results/ 2>/dev/null || true
 
       - name: Upload E2E benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 📝 Description

### What
Add a separate benchmark chart for E2E memory metrics (heap usage in MB) on the gh-pages benchmark dashboard, and fix duplicate graphs caused by benchmark name renames.

### Why
Memory benchmarks (21-25) from js-framework-benchmark were mixed into the CPU timing chart with an incorrect "ms" unit label. They should be displayed in a dedicated chart with the correct "MB" unit. Additionally, historical benchmark data was duplicated under both old and new chart names after a rename.

### How
1. **`convert-e2e-results.py`**: Added `--output-memory` flag and `is_memory_benchmark()` helper to split results into CPU-only (01-09, unit: ms) and memory-only (21-26, unit: MB) output files.
2. **`benchmark.yml`**: Added `--output-memory ./e2e-benchmark-memory.json` to the convert step, a new store step for `"1. E2E Benchmark: Memory (js-framework-benchmark)"`, and includes the memory file in artifact uploads.
3. **`index.html` (gh-pages)**: Already pushed — merge logic consolidates old benchmark names into new names at render time, eliminating duplicate charts while preserving historical data.

## 🔗 Related Issues

Related to benchmark dashboard improvements

## ✅ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build/CI configuration change

## 🧪 Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

### Testing Details

- Verified `convert-e2e-results.py` correctly splits CPU/memory benchmarks by prefix (01-09 vs 21-26)
- Verified `is_memory_benchmark()` correctly identifies memory benchmark names
- Confirmed `--output-memory` flag is optional (backward compatible)
- Verified gh-pages `index.html` merge logic consolidates old→new chart names correctly

## ✨ Changes Made

- Added `is_memory_benchmark()` helper function to `convert-e2e-results.py`
- Added `--output-memory` CLI argument for separate memory benchmark output
- Split `convert_to_benchmark_format()` with `memory_only` parameter to filter by benchmark type
- Memory benchmarks now use correct `"unit": "MB"` instead of `"ms"`
- Added new workflow store step: `"1. E2E Benchmark: Memory (js-framework-benchmark)"` with 120% alert threshold
- Memory results file included in artifact upload

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

On the next push to `main`, the benchmark workflow will produce two E2E output files instead of one. A new "1. E2E Benchmark: Memory" chart will appear on the gh-pages dashboard. The duplicate graph fix (index.html on gh-pages) is already live.