### PR TITLE
feat: Add Roslyn analyzers for HTML validation (ABIES001-005)

### DIFF
--- a/Abies.Analyzers.Tests/Abies.Analyzers.Tests.csproj
+++ b/Abies.Analyzers.Tests/Abies.Analyzers.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />
+    <!-- Pin Roslyn versions to resolve conflicts with Praefixum transitive deps -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Abies.Analyzers\Abies.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Abies.Analyzers.Tests/AbiesStubs.cs
+++ b/Abies.Analyzers.Tests/AbiesStubs.cs
@@ -1,0 +1,109 @@
+namespace Abies.Analyzers.Tests;
+
+/// <summary>
+/// Minimal source-code stubs that mirror the public API surface of Abies.DOM,
+/// Abies.Html.Elements, and Abies.Html.Attributes. These are compiled into the
+/// Roslyn test harness's in-memory compilation so the semantic model can resolve
+/// types without referencing the real Abies assembly (which targets net10.0 and
+/// causes CS1705 version mismatches with the net8.0 reference assemblies used
+/// by the test framework).
+/// </summary>
+internal static class AbiesStubs
+{
+    /// <summary>
+    /// Source code containing minimal Abies type definitions.
+    /// Add this to every analyzer test via <c>TestState.Sources.Add</c>.
+    /// </summary>
+    public const string Source = """
+        // ── Abies.DOM stubs ──────────────────────────────────────────
+        namespace Abies.DOM
+        {
+            public record Node(string Id);
+            public record Element(string Id, string Tag, Attribute[] Attributes, params Node[] Children) : Node(Id);
+            public record Text(string Id, string Value) : Node(Id);
+            public record Attribute(string Id, string Name, string Value);
+        }
+        
+        // ── Abies.Html.Elements stubs ────────────────────────────────
+        namespace Abies.Html
+        {
+            using Abies.DOM;
+        
+            public static class Elements
+            {
+                // Non-void elements: (attributes, children, id?) → Node
+                public static Node a(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "a", attributes, children);
+        
+                public static Node div(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "div", attributes, children);
+        
+                public static Node span(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "span", attributes, children);
+        
+                public static Node p(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "p", attributes, children);
+        
+                public static Node button(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "button", attributes, children);
+        
+                public static Node h1(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "h1", attributes, children);
+        
+                public static Node strong(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "strong", attributes, children);
+        
+                public static Node em(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "em", attributes, children);
+        
+                public static Node section(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "section", attributes, children);
+        
+                public static Node table(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "table", attributes, children);
+        
+                public static Node tr(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "tr", attributes, children);
+        
+                public static Node td(Attribute[] attributes, Node[] children, string? id = null)
+                    => new Element(id ?? "", "td", attributes, children);
+        
+                // Void elements: (attributes, id?) → Node  (no children parameter)
+                public static Node img(Attribute[] attributes, string? id = null)
+                    => new Element(id ?? "", "img", attributes);
+        
+                public static Node input(Attribute[] attributes, string? id = null)
+                    => new Element(id ?? "", "input", attributes);
+        
+                // Text factory: (value, id?) → Node
+                public static Node text(string value, string? id = null)
+                    => new Text(id ?? "", value);
+            }
+        }
+        
+        // ── Abies.Html.Attributes stubs ──────────────────────────────
+        namespace Abies.Html
+        {
+            public static class Attributes
+            {
+                public static DOM.Attribute src(string value, string? id = null)
+                    => new(id ?? "", "src", value);
+        
+                public static DOM.Attribute alt(string value, string? id = null)
+                    => new(id ?? "", "alt", value);
+        
+                public static DOM.Attribute href(string value, string? id = null)
+                    => new(id ?? "", "href", value);
+        
+                public static DOM.Attribute class_(string value, string? id = null)
+                    => new(id ?? "", "class", value);
+        
+                public static DOM.Attribute type(string value, string? id = null)
+                    => new(id ?? "", "type", value);
+        
+                public static DOM.Attribute placeholder(string value, string? id = null)
+                    => new(id ?? "", "placeholder", value);
+            }
+        }
+        """;
+}

--- a/Abies.Analyzers.Tests/ContentModelAnalyzerTests.cs
+++ b/Abies.Analyzers.Tests/ContentModelAnalyzerTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Abies.Analyzers.Tests;
+
+/// <summary>
+/// Tests for <see cref="ContentModelAnalyzer"/> — verifies that ABIES002 fires correctly.
+/// </summary>
+public class ContentModelAnalyzerTests
+{
+    private const string Preamble = """
+        using Abies.Html;
+        using static Abies.Html.Elements;
+        using static Abies.Html.Attributes;
+        using Abies.DOM;
+        
+        namespace TestApp;
+        
+        public static class TestView
+        {
+        """;
+
+    private const string Postamble = """
+        }
+        """;
+
+    private static string WrapInView(string code) => Preamble + code + Postamble;
+
+    private static CSharpAnalyzerTest<ContentModelAnalyzer, DefaultVerifier> CreateTest(string testCode)
+    {
+        var test = new CSharpAnalyzerTest<ContentModelAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("AbiesStubs.cs", AbiesStubs.Source));
+        return test;
+    }
+
+    // =========================================================================
+    // ABIES002: Block inside inline
+    // =========================================================================
+
+    [Fact]
+    public async Task DivInsideSpan_ReportsABIES002()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    span([], [{|#0:div([], [text("oops")])|} ]);
+            """));
+
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES002", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("div", "span"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task SectionInsideStrong_ReportsABIES002()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    strong([], [{|#0:section([], [text("wrong")])|} ]);
+            """));
+
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES002", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("section", "strong"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TableInsideH1_ReportsABIES002()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    h1([], [{|#0:table([], [tr([], [td([], [text("data")])])])|} ]);
+            """));
+
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES002", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("table", "h1"));
+
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // Valid nesting — should NOT report
+    // =========================================================================
+
+    [Fact]
+    public async Task SpanInsideDiv_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    div([], [span([], [text("ok")])]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task DivInsideDiv_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    div([], [div([], [text("ok")])]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task SpanInsideSpan_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    span([], [strong([], [em([], [text("ok")])])]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TextInsideParagraph_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    p([], [text("hello")]);
+            """));
+
+        await test.RunAsync();
+    }
+}

--- a/Abies.Analyzers.Tests/MissingAttributeAnalyzerTests.cs
+++ b/Abies.Analyzers.Tests/MissingAttributeAnalyzerTests.cs
@@ -1,0 +1,190 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Abies.Analyzers.Tests;
+
+/// <summary>
+/// Tests for <see cref="MissingAttributeAnalyzer"/> — verifies that ABIES001, ABIES003-ABIES005 fire correctly.
+/// </summary>
+public class MissingAttributeAnalyzerTests
+{
+    // Preamble code that sets up the using directives and namespace context
+    private const string Preamble = """
+        using Abies.Html;
+        using static Abies.Html.Elements;
+        using static Abies.Html.Attributes;
+        using Abies.DOM;
+        
+        namespace TestApp;
+        
+        public static class TestView
+        {
+        """;
+
+    private const string Postamble = """
+        }
+        """;
+
+    private static string WrapInView(string code) => Preamble + code + Postamble;
+
+    private static CSharpAnalyzerTest<MissingAttributeAnalyzer, DefaultVerifier> CreateTest(string testCode)
+    {
+        var test = new CSharpAnalyzerTest<MissingAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("AbiesStubs.cs", AbiesStubs.Source));
+        return test;
+    }
+
+    // =========================================================================
+    // ABIES001: img() missing alt
+    // =========================================================================
+
+    [Fact]
+    public async Task ImgWithoutAlt_ReportsABIES001()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    {|#0:img([src("image.jpg")])|};
+            """));
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("ABIES001", DiagnosticSeverity.Warning).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ImgWithAlt_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    img([src("image.jpg"), alt("A photo")]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ImgWithEmptyAlt_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    img([src("image.jpg"), alt("")]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // ABIES003: a() missing href
+    // =========================================================================
+
+    [Fact]
+    public async Task AnchorWithoutHref_ReportsABIES003()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    {|#0:a([class_("nav-link")], [text("Click me")])|};
+            """));
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("ABIES003", DiagnosticSeverity.Info).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AnchorWithHref_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    a([class_("nav-link"), href("/home")], [text("Home")]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // ABIES004: button() missing type
+    // =========================================================================
+
+    [Fact]
+    public async Task ButtonWithoutType_ReportsABIES004()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    {|#0:button([class_("btn")], [text("Click")])|};
+            """));
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("ABIES004", DiagnosticSeverity.Info).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ButtonWithType_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    button([class_("btn"), type("button")], [text("Click")]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // ABIES005: input() missing type
+    // =========================================================================
+
+    [Fact]
+    public async Task InputWithoutType_ReportsABIES005()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    {|#0:input([placeholder("Enter text")])|};
+            """));
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult("ABIES005", DiagnosticSeverity.Info).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task InputWithType_NoDiagnostic()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    input([type("email"), placeholder("Enter email")]);
+            """));
+
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    [Fact]
+    public async Task NonAbiesCode_NoDiagnostic()
+    {
+        // Code that doesn't use Abies elements should produce no diagnostics
+        var test = new CSharpAnalyzerTest<MissingAttributeAnalyzer, DefaultVerifier>
+        {
+            TestCode = """
+                namespace TestApp;
+                
+                public static class Foo
+                {
+                    public static string img(string x) => x;
+                    public static string Test() => img("test");
+                }
+                """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+
+        await test.RunAsync();
+    }
+}

--- a/Abies.Analyzers/Abies.Analyzers.csproj
+++ b/Abies.Analyzers/Abies.Analyzers.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+
+    <!-- Exclude from Directory.Build.props global usings (ValueTuple alias needs System which isn't in netstandard2.0 the same way) -->
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Do NOT include the global usings from Directory.Build.props -->
+    <Compile Remove="$(MSBuildThisFileDirectory)..\Global\Usings.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)..\Global\Suppressions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/Abies.Analyzers/AnalysisHelpers.cs
+++ b/Abies.Analyzers/AnalysisHelpers.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Abies.Analyzers;
+
+/// <summary>
+/// Shared helper methods for analyzing Abies.Html element and attribute invocations.
+/// </summary>
+internal static class AnalysisHelpers
+{
+    private const string _elementsTypeName = "Abies.Html.Elements";
+    private const string _attributesTypeName = "Abies.Html.Attributes";
+
+    /// <summary>
+    /// Attempts to determine the HTML element name from an invocation expression
+    /// that calls a method on Abies.Html.Elements.
+    /// </summary>
+    /// <returns>The element name (e.g., "div", "img", "span") or null if not an Elements call.</returns>
+    public static string? GetElementName(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+        {
+            return null;
+        }
+
+        var containingType = method.ContainingType?.ToDisplayString();
+        if (containingType != _elementsTypeName)
+        {
+            return null;
+        }
+
+        // The method name IS the element name (e.g., Elements.div → "div", Elements.img → "img")
+        // Exception: element() is the generic factory, skip it
+        var name = method.Name;
+        if (name == "element" || name == "text" || name == "raw" || name == "memo" || name == "lazy")
+        {
+            return null;
+        }
+
+        // Handle C# escaped names like @base → "base", object_ → "object"
+        if (name.EndsWith("_"))
+        {
+            name = name.Substring(0, name.Length - 1);
+        }
+
+        return name;
+    }
+
+    /// <summary>
+    /// Extracts the set of attribute names used in the first argument (attributes array)
+    /// of an element invocation.
+    /// </summary>
+    /// <returns>A set of HTML attribute names found in the attributes argument.</returns>
+    public static ImmutableHashSet<string> GetAttributeNames(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        var builder = ImmutableHashSet.CreateBuilder<string>();
+
+        // The first argument is the attributes array: DOM.Attribute[]
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count == 0)
+        {
+            return builder.ToImmutable();
+        }
+
+        var firstArg = args[0].Expression;
+        var attributeExpressions = GetCollectionElements(firstArg);
+
+        foreach (var expr in attributeExpressions)
+        {
+            var attrName = GetAttributeName(expr, semanticModel);
+            if (attrName != null)
+            {
+                builder.Add(attrName);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Extracts the element names used in the children argument (second argument)
+    /// of an element invocation.
+    /// </summary>
+    /// <returns>A list of (childElementName, childInvocationLocation) tuples.</returns>
+    public static ImmutableArray<(string ElementName, Location Location)> GetChildElementNames(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        var builder = ImmutableArray.CreateBuilder<(string, Location)>();
+
+        // Children are the second argument: Node[]
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count < 2)
+        {
+            return builder.ToImmutable();
+        }
+
+        var secondArg = args[1].Expression;
+        var childExpressions = GetCollectionElements(secondArg);
+
+        foreach (var expr in childExpressions)
+        {
+            if (expr is InvocationExpressionSyntax childInvocation)
+            {
+                var childName = GetElementName(childInvocation, semanticModel);
+                if (childName != null)
+                {
+                    builder.Add((childName, childInvocation.GetLocation()));
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Determines the attribute name from an expression that is expected to be
+    /// a call to an Attributes.* factory function.
+    /// </summary>
+    private static string? GetAttributeName(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel)
+    {
+        if (expression is not InvocationExpressionSyntax attrInvocation)
+        {
+            return null;
+        }
+
+        var symbolInfo = semanticModel.GetSymbolInfo(attrInvocation);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+        {
+            return null;
+        }
+
+        var containingType = method.ContainingType?.ToDisplayString();
+        if (containingType != _attributesTypeName)
+        {
+            return null;
+        }
+
+        // The method name maps to the attribute name
+        var name = method.Name;
+
+        // Handle C# name escaping: class_ → "class", for_ → "for", etc.
+        // But "attribute" is the generic factory — need to extract the name from the first arg
+        if (name == "attribute")
+        {
+            // attribute("name", "value") — extract the first string literal arg
+            if (attrInvocation.ArgumentList.Arguments.Count > 0)
+            {
+                var firstArg = attrInvocation.ArgumentList.Arguments[0].Expression;
+                var constValue = semanticModel.GetConstantValue(firstArg);
+                if (constValue.HasValue && constValue.Value is string strValue)
+                {
+                    return strValue;
+                }
+            }
+            return null;
+        }
+
+        // Some attribute methods have trailing underscore: class_ → class, for_ → for
+        if (name.EndsWith("_"))
+        {
+            name = name.Substring(0, name.Length - 1);
+        }
+
+        // Some attribute methods use camelCase for hyphenated: ariaLabel → aria-label
+        // But the actual HTML attribute name is what matters for checking — and the 
+        // attribute() constructor maps the name correctly. We just need the conceptual name.
+        // For our purposes, the method name (after _ removal) is sufficient for matching
+        // against our spec tables since they use the same naming convention.
+        return name;
+    }
+
+    /// <summary>
+    /// Extracts individual expressions from a collection expression, array creation,
+    /// or implicit array creation syntax.
+    /// Handles: [a, b, c], new[] { a, b, c }, new DOM.Attribute[] { a, b, c }
+    /// </summary>
+    private static IEnumerable<ExpressionSyntax> GetCollectionElements(ExpressionSyntax expression)
+    {
+        // C# 12 collection expression: [a, b, c]
+        if (expression is CollectionExpressionSyntax collectionExpr)
+        {
+            foreach (var element in collectionExpr.Elements)
+            {
+                if (element is ExpressionElementSyntax exprElement)
+                {
+                    yield return exprElement.Expression;
+                }
+                else if (element is SpreadElementSyntax spread)
+                {
+                    yield return spread.Expression;
+                }
+            }
+            yield break;
+        }
+
+        // Implicit array: new[] { a, b, c }
+        if (expression is ImplicitArrayCreationExpressionSyntax implicitArray)
+        {
+            if (implicitArray.Initializer != null)
+            {
+                foreach (var elem in implicitArray.Initializer.Expressions)
+                {
+                    yield return elem;
+                }
+            }
+            yield break;
+        }
+
+        // Explicit array: new DOM.Attribute[] { a, b, c }
+        if (expression is ArrayCreationExpressionSyntax arrayCreation)
+        {
+            if (arrayCreation.Initializer != null)
+            {
+                foreach (var elem in arrayCreation.Initializer.Expressions)
+                {
+                    yield return elem;
+                }
+            }
+            yield break;
+        }
+
+        // InitializerExpression (bare { a, b, c } used in some contexts)
+        if (expression is InitializerExpressionSyntax initializer)
+        {
+            foreach (var elem in initializer.Expressions)
+            {
+                yield return elem;
+            }
+
+            yield break;
+        }
+    }
+}

--- a/Abies.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Abies.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,11 @@
+## Release 1.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+ABIES001 | Abies.Html.Accessibility | Warning | MissingAttributeAnalyzer, img() missing alt attribute
+ABIES002 | Abies.Html.ContentModel | Warning | ContentModelAnalyzer, block element inside inline element
+ABIES003 | Abies.Html | Info | MissingAttributeAnalyzer, a() missing href attribute
+ABIES004 | Abies.Html | Info | MissingAttributeAnalyzer, button() missing type attribute
+ABIES005 | Abies.Html | Info | MissingAttributeAnalyzer, input() missing type attribute

--- a/Abies.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Abies.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Abies.Analyzers/ContentModelAnalyzer.cs
+++ b/Abies.Analyzers/ContentModelAnalyzer.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Abies.Analyzers;
+
+/// <summary>
+/// Roslyn analyzer that detects HTML content model violations in Abies.Html element trees.
+/// </summary>
+/// <remarks>
+/// Detected issues:
+/// <list type="bullet">
+/// <item>ABIES002: Block (flow) element nested inside an inline (phrasing-only) element</item>
+/// </list>
+/// 
+/// This analyzer walks the invocation tree to detect when flow content elements
+/// (like div, section, table) are placed as children of phrasing-only elements
+/// (like span, strong, em, h1-h6, p).
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ContentModelAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.BlockInsideInline);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Resolve the parent element name
+        var parentElementName = AnalysisHelpers.GetElementName(invocation, context.SemanticModel);
+        if (parentElementName == null)
+        {
+            return;
+        }
+
+        // Only check elements that are phrasing-only parents
+        if (!HtmlSpec.PhrasingOnlyParents.Contains(parentElementName))
+        {
+            return;
+        }
+
+        // Get the child element names from the children argument
+        var children = AnalysisHelpers.GetChildElementNames(invocation, context.SemanticModel);
+
+        foreach (var (childName, childLocation) in children)
+        {
+            // Check if this child is a flow content element (block-level)
+            if (HtmlSpec.FlowContentElements.Contains(childName))
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DiagnosticDescriptors.BlockInsideInline,
+                        childLocation,
+                        childName,
+                        parentElementName));
+            }
+        }
+    }
+}

--- a/Abies.Analyzers/DiagnosticDescriptors.cs
+++ b/Abies.Analyzers/DiagnosticDescriptors.cs
@@ -1,0 +1,78 @@
+using Microsoft.CodeAnalysis;
+
+namespace Abies.Analyzers;
+
+/// <summary>
+/// Central registry of all Abies HTML analyzer diagnostic descriptors.
+/// </summary>
+internal static class DiagnosticDescriptors
+{
+    private const string _category = "Abies.Html";
+    private const string _accessibilityCategory = "Abies.Html.Accessibility";
+    private const string _contentModelCategory = "Abies.Html.ContentModel";
+
+    // =========================================================================
+    // ABIES001: img() missing alt attribute
+    // =========================================================================
+    public static readonly DiagnosticDescriptor ImgMissingAlt = new(
+        id: "ABIES001",
+        title: "img element missing 'alt' attribute",
+        messageFormat: "img() should include an alt() attribute for accessibility; use alt(\"\") for decorative images",
+        category: _accessibilityCategory,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The HTML specification requires the 'alt' attribute on <img> elements. Screen readers use this to describe images to users who cannot see them. Use alt(\"\") for purely decorative images.",
+        helpLinkUri: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#accessibility");
+
+    // =========================================================================
+    // ABIES002: Block element inside phrasing-only (inline) element
+    // =========================================================================
+    public static readonly DiagnosticDescriptor BlockInsideInline = new(
+        id: "ABIES002",
+        title: "Block element nested inside inline element",
+        messageFormat: "'{0}' (flow content) should not be nested inside '{1}' (phrasing content only)",
+        category: _contentModelCategory,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "HTML content model rules prohibit placing flow content (block-level elements like <div>, <p>, <section>) inside elements that only accept phrasing content (like <span>, <strong>, <em>). This can cause unpredictable browser rendering.",
+        helpLinkUri: "https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content");
+
+    // =========================================================================
+    // ABIES003: a() missing href attribute
+    // =========================================================================
+    public static readonly DiagnosticDescriptor AnchorMissingHref = new(
+        id: "ABIES003",
+        title: "a element missing 'href' attribute",
+        messageFormat: "a() should include an href() attribute; without href the anchor is not interactive",
+        category: _category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "An <a> element without an href attribute is not a hyperlink. While technically valid, this is usually unintentional.",
+        helpLinkUri: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#href");
+
+    // =========================================================================
+    // ABIES004: button() missing type attribute
+    // =========================================================================
+    public static readonly DiagnosticDescriptor ButtonMissingType = new(
+        id: "ABIES004",
+        title: "button element missing 'type' attribute",
+        messageFormat: "button() should include a type() attribute; default type is 'submit' which may cause unexpected form submissions",
+        category: _category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "A <button> element without an explicit type attribute defaults to type='submit'. This can cause unexpected form submissions. Always specify type('button'), type('submit'), or type('reset').",
+        helpLinkUri: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type");
+
+    // =========================================================================
+    // ABIES005: input() missing type attribute
+    // =========================================================================
+    public static readonly DiagnosticDescriptor InputMissingType = new(
+        id: "ABIES005",
+        title: "input element missing 'type' attribute",
+        messageFormat: "input() should include a type() attribute; default type is 'text' but being explicit improves readability",
+        category: _category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "An <input> element without an explicit type attribute defaults to type='text'. Being explicit about the input type improves code readability and makes the intent clear.",
+        helpLinkUri: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#type");
+}

--- a/Abies.Analyzers/HtmlSpec.cs
+++ b/Abies.Analyzers/HtmlSpec.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Abies.Analyzers;
+
+/// <summary>
+/// HTML specification knowledge base for analyzer rules.
+/// Contains content model categories, required attributes, and element metadata.
+/// </summary>
+/// <remarks>
+/// Based on the WHATWG HTML Living Standard:
+/// https://html.spec.whatwg.org/multipage/dom.html#content-models
+/// </remarks>
+internal static class HtmlSpec
+{
+    /// <summary>
+    /// Elements that accept only phrasing content (inline elements).
+    /// Placing flow content (block elements) inside these is a content model violation.
+    /// </summary>
+    public static readonly ImmutableHashSet<string> PhrasingOnlyParents = ImmutableHashSet.Create(
+        // Text-level semantics (phrasing content model)
+        "span", "strong", "em", "small", "s", "cite", "q", "dfn",
+        "abbr", "code", "var", "samp", "kbd", "sub", "sup",
+        "i", "b", "u", "mark", "bdi", "bdo", "time",
+        // Heading elements (phrasing content model)
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        // Other phrasing-only parents
+        "label", "legend", "caption", "summary", "figcaption",
+        "dt", "option", "p"
+    );
+
+    /// <summary>
+    /// Flow content elements (block-level elements) that should NOT appear
+    /// inside phrasing-only parents.
+    /// </summary>
+    public static readonly ImmutableHashSet<string> FlowContentElements = ImmutableHashSet.Create(
+        // Sectioning content
+        "article", "aside", "nav", "section",
+        // Heading content
+        "h1", "h2", "h3", "h4", "h5", "h6", "hgroup",
+        // Grouping content
+        "div", "p", "hr", "pre", "blockquote",
+        "ol", "ul", "li", "dl", "dd",
+        "figure", "figcaption", "main",
+        // Table content
+        "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+        "caption", "colgroup", "col",
+        // Form content
+        "form", "fieldset",
+        // Interactive content  
+        "details", "dialog",
+        // Other flow content
+        "header", "footer", "address"
+    );
+
+    /// <summary>
+    /// Required attributes per element, mapping element name → set of required attribute names.
+    /// </summary>
+    public static readonly ImmutableDictionary<string, ImmutableArray<RequiredAttribute>> RequiredAttributes =
+        ImmutableDictionary.CreateRange(new[]
+        {
+            new KeyValuePair<string, ImmutableArray<RequiredAttribute>>(
+                "img",
+                ImmutableArray.Create(
+                    new RequiredAttribute("alt", "ABIES001")
+                )),
+        });
+
+    /// <summary>
+    /// Recommended attributes per element, mapping element name → set of recommended attribute names.
+    /// These produce Info-level diagnostics.
+    /// </summary>
+    public static readonly ImmutableDictionary<string, ImmutableArray<RecommendedAttribute>> RecommendedAttributes =
+        ImmutableDictionary.CreateRange(new[]
+        {
+            new KeyValuePair<string, ImmutableArray<RecommendedAttribute>>(
+                "a",
+                ImmutableArray.Create(
+                    new RecommendedAttribute("href", "ABIES003")
+                )),
+            new KeyValuePair<string, ImmutableArray<RecommendedAttribute>>(
+                "button",
+                ImmutableArray.Create(
+                    new RecommendedAttribute("type", "ABIES004")
+                )),
+            new KeyValuePair<string, ImmutableArray<RecommendedAttribute>>(
+                "input",
+                ImmutableArray.Create(
+                    new RecommendedAttribute("type", "ABIES005")
+                )),
+        });
+}
+
+/// <summary>
+/// Represents an attribute that the HTML spec requires on an element.
+/// </summary>
+internal readonly struct RequiredAttribute
+{
+    public string AttributeName { get; }
+    public string DiagnosticId { get; }
+
+    public RequiredAttribute(string attributeName, string diagnosticId)
+    {
+        AttributeName = attributeName;
+        DiagnosticId = diagnosticId;
+    }
+}
+
+/// <summary>
+/// Represents an attribute that is strongly recommended on an element.
+/// </summary>
+internal readonly struct RecommendedAttribute
+{
+    public string AttributeName { get; }
+    public string DiagnosticId { get; }
+
+    public RecommendedAttribute(string attributeName, string diagnosticId)
+    {
+        AttributeName = attributeName;
+        DiagnosticId = diagnosticId;
+    }
+}

--- a/Abies.Analyzers/MissingAttributeAnalyzer.cs
+++ b/Abies.Analyzers/MissingAttributeAnalyzer.cs
@@ -1,0 +1,97 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Abies.Analyzers;
+
+/// <summary>
+/// Roslyn analyzer that detects missing required and recommended HTML attributes
+/// on Abies.Html.Elements factory function calls.
+/// </summary>
+/// <remarks>
+/// Detected issues:
+/// <list type="bullet">
+/// <item>ABIES001: img() missing alt attribute (Warning)</item>
+/// <item>ABIES003: a() missing href attribute (Info)</item>
+/// <item>ABIES004: button() missing type attribute (Info)</item>
+/// <item>ABIES005: input() missing type attribute (Info)</item>
+/// </list>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingAttributeAnalyzer : DiagnosticAnalyzer
+{
+    // Map diagnostic IDs to their descriptors for quick lookup
+    private static readonly ImmutableDictionary<string, DiagnosticDescriptor> _descriptorMap =
+        ImmutableDictionary.CreateRange(new[]
+        {
+            new System.Collections.Generic.KeyValuePair<string, DiagnosticDescriptor>(
+                "ABIES001", DiagnosticDescriptors.ImgMissingAlt),
+            new System.Collections.Generic.KeyValuePair<string, DiagnosticDescriptor>(
+                "ABIES003", DiagnosticDescriptors.AnchorMissingHref),
+            new System.Collections.Generic.KeyValuePair<string, DiagnosticDescriptor>(
+                "ABIES004", DiagnosticDescriptors.ButtonMissingType),
+            new System.Collections.Generic.KeyValuePair<string, DiagnosticDescriptor>(
+                "ABIES005", DiagnosticDescriptors.InputMissingType),
+        });
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            DiagnosticDescriptors.ImgMissingAlt,
+            DiagnosticDescriptors.AnchorMissingHref,
+            DiagnosticDescriptors.ButtonMissingType,
+            DiagnosticDescriptors.InputMissingType);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Resolve the element name from the invocation
+        var elementName = AnalysisHelpers.GetElementName(invocation, context.SemanticModel);
+        if (elementName == null)
+        {
+            return;
+        }
+
+        // Check required attributes (Warning severity)
+        if (HtmlSpec.RequiredAttributes.TryGetValue(elementName, out var requiredAttrs))
+        {
+            var presentAttrs = AnalysisHelpers.GetAttributeNames(invocation, context.SemanticModel);
+
+            foreach (var req in requiredAttrs)
+            {
+                if (!presentAttrs.Contains(req.AttributeName) &&
+                    _descriptorMap.TryGetValue(req.DiagnosticId, out var descriptor))
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(descriptor, invocation.GetLocation()));
+                }
+            }
+        }
+
+        // Check recommended attributes (Info severity)
+        if (HtmlSpec.RecommendedAttributes.TryGetValue(elementName, out var recommendedAttrs))
+        {
+            var presentAttrs = AnalysisHelpers.GetAttributeNames(invocation, context.SemanticModel);
+
+            foreach (var rec in recommendedAttrs)
+            {
+                if (!presentAttrs.Contains(rec.AttributeName) &&
+                    _descriptorMap.TryGetValue(rec.DiagnosticId, out var descriptor))
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(descriptor, invocation.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/Abies.Conduit/Abies.Conduit.csproj
+++ b/Abies.Conduit/Abies.Conduit.csproj
@@ -21,6 +21,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Abies\Abies.csproj" />
+    <!-- HTML analyzer (automatic for NuGet consumers; explicit for ProjectReference) -->
+    <ProjectReference Include="..\Abies.Analyzers\Abies.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.45.0" />
@@ -32,12 +37,12 @@
     <!-- Dotnet watch: restart when the canonical file changes -->
     <Watch Include="..\Abies\wwwroot\abies.js" />
   </ItemGroup>
-  
+
   <!-- Copy the canonical abies.js before build/publish -->
   <Target Name="SyncAbiesJs" BeforeTargets="Build;ComputeFilesToPublish" Inputs="..\Abies\wwwroot\abies.js" Outputs="wwwroot\abies.js">
     <Copy SourceFiles="..\Abies\wwwroot\abies.js" DestinationFiles="wwwroot\abies.js" />
   </Target>
-  
+
   <!-- Remove the Abies project's copy from publish to avoid NETSDK1152 duplicate -->
   <Target Name="RemoveDuplicateAbiesJs" AfterTargets="ComputeFilesToPublish">
     <ItemGroup>

--- a/Abies.Conduit/Page/Article.cs
+++ b/Abies.Conduit/Page/Article.cs
@@ -147,7 +147,7 @@ public class Page : Element<Model, Message>
 
     private static Node ArticleMeta(Home.Article article, bool showEditDelete = false) =>
         div([class_("article-meta")], [            a([href($"/profile/{article.Author.Username}")], [
-                img([src(article.Author.Image)])
+                img([src(article.Author.Image), alt($"{article.Author.Username} profile image")])
             ]),            div([class_("info")], [
                 a([href($"/profile/{article.Author.Username}")], [
                     text(article.Author.Username)
@@ -235,7 +235,7 @@ public class Page : Element<Model, Message>
                     ], [text(model.CommentInput)])
                 ]),
                 div([class_("card-footer")], [
-                    img([class_("comment-author-img"), src(model.CurrentUser?.Image ?? "")]),
+                    img([class_("comment-author-img"), src(model.CurrentUser?.Image ?? ""), alt($"{model.CurrentUser?.Username.Value ?? "User"} profile image")]),
                     button([
                         class_("btn btn-sm btn-primary"),
                         type("submit"),
@@ -251,7 +251,7 @@ public class Page : Element<Model, Message>
                 p([class_("card-text")], [text(comment.Body)])
             ]),
             div([class_("card-footer")], [                a([class_("comment-author"), href($"/profile/{comment.Author.Username}")], [
-                    img([class_("comment-author-img"), src(comment.Author.Image)])
+                    img([class_("comment-author-img"), src(comment.Author.Image), alt($"{comment.Author.Username} profile image")])
                 ]),
                 text(" "),
                 a([class_("comment-author"), href($"/profile/{comment.Author.Username}")], [

--- a/Abies.Conduit/Page/Home.cs
+++ b/Abies.Conduit/Page/Home.cs
@@ -194,7 +194,7 @@ public class Page : Element<Model, Message>
         div([class_("article-preview")], [
             div([class_("article-meta")], [
                 a([href($"/profile/{article.Author.Username}")], [
-                    img([src(article.Author.Image)])
+                    img([src(article.Author.Image), alt($"{article.Author.Username} profile image")])
                 ]),
                 div([class_("info")], [
                     a([class_("author"), href($"/profile/{article.Author.Username}")], [

--- a/Abies.Conduit/Page/Profile.cs
+++ b/Abies.Conduit/Page/Profile.cs
@@ -118,7 +118,7 @@ public class Page : Element<Model, Message>
             div([class_("container")], [
                 div([class_("row")], [
                     div([class_("col-xs-12 col-md-10 offset-md-1")], [
-                        img([class_("user-img"), src(model.Profile?.Image ?? "")]),
+                        img([class_("user-img"), src(model.Profile?.Image ?? ""), alt($"{model.UserName.Value} profile image")]),
                         h4([], [text(model.UserName.Value)]),
                         p([], [text(model.Profile?.Bio ?? "")]),
                         isCurrentUser
@@ -165,7 +165,7 @@ public class Page : Element<Model, Message>
         div([class_("article-preview")], [
             div([class_("article-meta")], [
                 a([href($"/profile/{article.Author.Username}")], [
-                    img([src(article.Author.Image)])
+                    img([src(article.Author.Image), alt($"{article.Author.Username} profile image")])
                 ]),
                 div([class_("info")], [
                     a([class_("author"), href($"/profile/{article.Author.Username}")], [

--- a/Abies.sln
+++ b/Abies.sln
@@ -29,6 +29,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abies.Conduit.E2E", "Abies.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abies.Templates", "Abies.Templates\Abies.Templates.csproj", "{EF218F79-3513-4BE6-8FE1-F4B31328B24A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abies.Analyzers", "Abies.Analyzers\Abies.Analyzers.csproj", "{55E1557E-D7C1-45A4-A39C-5DFF482D3327}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Abies.Analyzers.Tests", "Abies.Analyzers.Tests\Abies.Analyzers.Tests.csproj", "{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +199,30 @@ Global
 		{EF218F79-3513-4BE6-8FE1-F4B31328B24A}.Release|x64.Build.0 = Release|Any CPU
 		{EF218F79-3513-4BE6-8FE1-F4B31328B24A}.Release|x86.ActiveCfg = Release|Any CPU
 		{EF218F79-3513-4BE6-8FE1-F4B31328B24A}.Release|x86.Build.0 = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|x64.Build.0 = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Debug|x86.Build.0 = Debug|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|x64.ActiveCfg = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|x64.Build.0 = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|x86.ActiveCfg = Release|Any CPU
+		{55E1557E-D7C1-45A4-A39C-5DFF482D3327}.Release|x86.Build.0 = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|x64.Build.0 = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE6210DF-47F7-4AC9-B75C-47F9222B8F6F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Abies/Abies.csproj
+++ b/Abies/Abies.csproj
@@ -48,4 +48,20 @@
     <PackageReference Include="Praefixum" Version="1.2.1-tags-v1-2-0.1" />
   </ItemGroup>
 
+  <!-- Run the HTML analyzer on the Abies library itself -->
+  <ItemGroup>
+    <ProjectReference Include="..\Abies.Analyzers\Abies.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Pack the analyzer DLL into the NuGet package so PackageReference consumers get it automatically -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\Abies.Analyzers\bin\$(Configuration)\netstandard2.0\Abies.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/docs/adr/ADR-021-html-validation-analyzers-over-typed-dsl.md
+++ b/docs/adr/ADR-021-html-validation-analyzers-over-typed-dsl.md
@@ -1,0 +1,193 @@
+# ADR-021: Roslyn Analyzers for HTML Validation over Type-Safe DSL
+
+**Status:** Accepted  
+**Date:** 2026-02-18  
+**Decision Makers:** Maurice Peters  
+**Related Issue:** [#86 — feat: Type-safe HTML DSL — make illegal states unrepresentable](https://github.com/Picea/Abies/issues/86)
+
+## Context
+
+The Abies HTML DSL is stringly typed — all elements return `Node`, all attributes return `DOM.Attribute`, and all attribute values are `string`. This means the type system allows many illegal HTML states that compile but produce invalid markup:
+
+```csharp
+// ❌ Compiles: <p> cannot contain <div> (phrasing vs flow content)
+p([], [div([], [text("nested")])])
+
+// ❌ Compiles: href is only valid on <a>, <area>, <base>, <link>
+div([href("/page")], [text("not a link")])
+
+// ❌ Compiles: <img> missing required alt attribute
+img([src("/photo.jpg")])
+```
+
+We explored two fundamentally different approaches to catching these errors at compile time:
+
+1. **Type-safe HTML DSL** — encode HTML content models and attribute validity into the C# type system itself
+2. **Roslyn analyzers** — keep the existing DSL unchanged and add compile-time diagnostics via analyzers
+
+A full prototype of the type-safe DSL was built (~9,300 lines across 90+ files) before the cost-benefit analysis led to its rejection.
+
+## Decision
+
+**Use Roslyn analyzers to validate HTML correctness at compile time, keeping the existing stringly-typed DSL unchanged.**
+
+The analyzer ships bundled inside the Abies NuGet package (`analyzers/dotnet/cs/`) so that all consumers — including template users — get HTML validation automatically with zero configuration.
+
+### Initial diagnostic rules
+
+| ID       | Severity | Rule                                                                         |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| ABIES001 | Warning  | `img()` must include `alt()` for accessibility                               |
+| ABIES002 | Warning  | Flow content (e.g., `div`) inside phrasing-only parents (e.g., `span`, `p`)  |
+| ABIES003 | Info     | `a()` should include `href()`                                                |
+| ABIES004 | Info     | `button()` should include `type()`                                           |
+| ABIES005 | Info     | `input()` should include `type()`                                            |
+
+### Distribution
+
+| Consumer                       | Mechanism                                         | Configuration needed |
+| ------------------------------ | ------------------------------------------------- | -------------------- |
+| NuGet / template users         | analyzers/dotnet/cs/ convention in NuGet package  | None — automatic     |
+| ProjectReference (in solution) | Explicit ProjectReference to Abies.Analyzers      | One line per project |
+
+## Consequences
+
+### Positive
+
+- **Zero migration cost** — existing Abies applications require no code changes
+- **Zero API surface change** — the DSL remains a single `Node` type; no breaking changes
+- **Familiar developer experience** — warnings appear in the IDE like any other diagnostic
+- **Incrementally extensible** — new rules can be added without touching the core framework
+- **Low maintenance burden** — analyzer project is ~500 lines, self-contained, netstandard2.0
+- **Automatic for NuGet consumers** — template users get validation out of the box
+- **Composability preserved** — `Node` remains a single type, so helper functions, `Select`, spread (`..`), and conditional rendering all work unchanged
+
+### Negative
+
+- **Not exhaustive at the type level** — analyzers can only check patterns they recognise; novel misuse patterns may slip through until a rule is added
+- **Heuristic-based** — relies on semantic model analysis of method calls, so indirect or dynamic construction may evade detection
+- **Two projects to maintain** — `Abies.Analyzers` (netstandard2.0) and `Abies.Analyzers.Tests` are separate from the main framework
+- **ProjectReference consumers need an explicit reference** — MSBuild does not propagate `OutputItemType="Analyzer"` transitively through project references
+
+### Neutral
+
+- Analyzer tests use inline type stubs (`AbiesStubs.cs`) rather than referencing the real `Abies.dll`, avoiding cross-TFM compatibility issues (netstandard2.0 vs net10.0)
+- Diagnostic severity levels are configurable via `.editorconfig`, so teams can promote Info rules to Warning or suppress rules as needed
+
+## Alternatives Considered
+
+### Alternative 1: Type-Safe HTML DSL (Rejected)
+
+A full prototype was built that encoded HTML content models into the C# type system using phantom type parameters and constrained generic interfaces:
+
+```csharp
+// Prototype approach — elements carry content model constraints
+public static Element<FlowContent> div<TContent>(
+    Attribute<HtmlDivElement>[] attributes,
+    TContent[] children) where TContent : FlowContent;
+
+public static Element<PhrasingContent> span<TContent>(
+    Attribute<HtmlSpanElement>[] attributes,
+    TContent[] children) where TContent : PhrasingContent;
+```
+
+**Why it was rejected:**
+
+1. **Massive API surface explosion** — ~90 new types for content models, element-specific attribute sets, and type constraints. Every HTML element needs its own attribute type, content model type, and constraint hierarchy.
+
+2. **C# type system limitations** — C# lacks union types and higher-kinded types, so encoding "this element accepts phrasing OR flow content" requires awkward workarounds (multiple overloads, marker interfaces, explicit casts). The prototype needed implicit conversion operators and bridge types to remain usable.
+
+3. **Breaks composability** — the single biggest cost. With typed elements, you cannot:
+   - Put a `div` and a `span` in the same array (different types)
+   - Write generic helper functions that return "any element"
+   - Use `Select()` to map over heterogeneous children
+   - Use spread (`..`) to flatten mixed content
+   - Use ternary expressions for conditional rendering
+
+   Every one of these patterns is common in real Abies applications (Conduit uses them extensively). The workaround — wrapper types, explicit casts, or `.AsNode()` calls everywhere — destroys the ergonomics that make the DSL pleasant to use.
+
+4. **Migration cost** — every existing Abies application would need rewriting. The Conduit app alone would require hundreds of changes across all page modules.
+
+5. **Ongoing maintenance burden** — every new HTML element or attribute requires updating the type hierarchy. The HTML spec evolves; keeping a parallel type system in sync is a permanent cost.
+
+6. **Diminishing returns** — the type system can catch nesting and attribute validity, but cannot enforce semantic rules (e.g., "forms need at least one submit button", "tables need `<th>` for accessibility"). Analyzers can encode arbitrary semantic rules.
+
+### Alternative 2: Source Generator (Considered, deferred)
+
+A source generator could analyze `View` functions and emit compile-time warnings for invalid HTML patterns, similar to what the analyzer does but with access to the full syntax tree at generation time.
+
+**Why deferred:**
+
+- Analyzers are simpler to implement and test
+- Source generators have stricter performance requirements (they run on every keystroke)
+- The analyzer approach can be migrated to a source generator later if needed
+- No clear advantage over analyzers for diagnostic-only use cases
+
+### Alternative 3: Runtime Validation (Rejected)
+
+Validate HTML structure at runtime during rendering or in development mode.
+
+**Why rejected:**
+
+- Errors only surface when the code path executes
+- No IDE feedback during development
+- Performance cost in production (even if dev-only, adds complexity)
+- Fundamentally less useful than compile-time validation
+
+## Implementation
+
+### Project structure
+
+```text
+Abies.Analyzers/                      # netstandard2.0, Roslyn 4.8.0
+├── DiagnosticDescriptors.cs          # ABIES001–ABIES005 definitions
+├── HtmlSpec.cs                       # HTML content model data
+├── AnalysisHelpers.cs                # Shared semantic model utilities
+├── MissingAttributeAnalyzer.cs       # ABIES001, ABIES003–ABIES005
+└── ContentModelAnalyzer.cs           # ABIES002
+
+Abies.Analyzers.Tests/                # net10.0, xUnit
+├── AbiesStubs.cs                     # Minimal type stubs for testing
+├── MissingAttributeAnalyzerTests.cs  # 12 tests
+└── ContentModelAnalyzerTests.cs      # 5 tests
+```
+
+### NuGet packaging (in `Abies.csproj`)
+
+```xml
+<!-- Run the analyzer on the Abies library itself -->
+<ProjectReference Include="..\Abies.Analyzers\Abies.Analyzers.csproj"
+                  ReferenceOutputAssembly="false"
+                  OutputItemType="Analyzer"
+                  PrivateAssets="all" />
+
+<!-- Pack the DLL into the NuGet package for consumers -->
+<None Include="...\Abies.Analyzers.dll"
+      Pack="true"
+      PackagePath="analyzers/dotnet/cs" />
+```
+
+### Extending with new rules
+
+To add a new diagnostic:
+
+1. Add a `DiagnosticDescriptor` to `DiagnosticDescriptors.cs`
+2. Create an analyzer class (or extend an existing one)
+3. Add the rule to `AnalyzerReleases.Unshipped.md`
+4. Add tests in `Abies.Analyzers.Tests`
+
+## Related Decisions
+
+- [ADR-001: MVU Architecture](./ADR-001-mvu-architecture.md) — the DSL serves the View function
+- [ADR-002: Pure Functional Programming](./ADR-002-pure-functional-programming.md) — composability of `Node` aligns with FP principles
+- [ADR-003: Virtual DOM](./ADR-003-virtual-dom.md) — `Node` is the VDOM tree type
+- [ADR-014: Compile-Time IDs](./ADR-014-compile-time-ids.md) — precedent for using Roslyn tooling (source generators) in the build
+
+## References
+
+- [GitHub Issue #86 — Type-safe HTML DSL](https://github.com/Picea/Abies/issues/86)
+- [PR #90 — Implementation](https://github.com/Picea/Abies/pull/90)
+- [Roslyn Analyzer Documentation](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
+- [NuGet Analyzer Convention](https://learn.microsoft.com/en-us/nuget/guides/analyzers-conventions)
+- [HTML Content Models (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories)
+- [Elm's approach — single `Html msg` type + runtime validation](https://package.elm-lang.org/packages/elm/html/latest/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ ADRs document significant architectural decisions, their context, and consequenc
 | [ADR-018](./ADR-018-pr-lint-only-changed-files.md) | PR Lint Check Only Changed Files | Accepted | Lint only PR-changed files, not entire solution |
 | [ADR-019](./ADR-019-trunk-based-development.md) | Trunk-Based Development | Accepted | Protected main branch with PR workflow |
 | [ADR-020](./ADR-020-benchmark-quality-gates.md) | Benchmark Quality Gates | Accepted | Automated quality gates for performance benchmarks |
+| [ADR-021](./ADR-021-html-validation-analyzers-over-typed-dsl.md) | HTML Validation via Roslyn Analyzers | Accepted | Analyzers over type-safe DSL for HTML correctness |
 
 > **Note:** There are two files numbered ADR-005: [ADR-005-webassembly-runtime.md](./ADR-005-webassembly-runtime.md) (indexed above) and [ADR-005-security-scanning-sast-dast-sca.md](./ADR-005-security-scanning-sast-dast-sca.md) (security scanning). The security scanning ADR was created separately and retains its number for historical reasons.
 


### PR DESCRIPTION
## 📝 Description

### What
Add Roslyn analyzers that validate HTML correctness at compile time for the Abies HTML DSL.

### Why
The Abies HTML DSL is stringly typed — all elements return `Node`, all attributes return `DOM.Attribute`, and all values are `string`. This means the type system allows illegal HTML states that compile but produce invalid markup (e.g., `img()` without `alt`, `div` nested inside `span`).

A full type-safe HTML DSL prototype was built (~9,300 lines, 90+ files) but was rejected due to massive API surface explosion, broken composability, and high migration cost. Roslyn analyzers achieve the same compile-time validation with zero breaking changes. See [ADR-021](docs/adr/ADR-021-html-validation-analyzers-over-typed-dsl.md) for the full decision record.

### How
Two analyzer classes inspect `InvocationExpressionSyntax` nodes via the Roslyn semantic model:
- **MissingAttributeAnalyzer** — checks for required/recommended attributes on element calls
- **ContentModelAnalyzer** — detects flow content nested inside phrasing-only parents

The analyzer DLL is bundled into the Abies NuGet package at `analyzers/dotnet/cs/`, so all consumers get validation automatically.

## 🔗 Related Issues

Resolves #86

## ✅ Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] ✅ Test update

## 🧪 Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

### Testing Details

- 17 analyzer unit tests covering all 5 diagnostic rules (happy paths + edge cases)
- Verified ABIES001 fires on real Conduit codebase (6 violations found and fixed)
- Verified NuGet package structure (`dotnet pack` produces correct `analyzers/dotnet/cs/` layout)
- All 105 existing Abies.Tests pass
- All 51 integration tests pass
- All 17 analyzer tests pass

## ✨ Changes Made

- Added `Abies.Analyzers` project (netstandard2.0, Roslyn 4.8.0) with 5 diagnostic rules:
  - **ABIES001** (Warning): `img()` missing `alt()` attribute
  - **ABIES002** (Warning): Flow content inside phrasing-only parents (e.g., `div` in `span`)
  - **ABIES003** (Info): `a()` missing `href()` attribute
  - **ABIES004** (Info): `button()` missing `type()` attribute
  - **ABIES005** (Info): `input()` missing `type()` attribute
- Added `Abies.Analyzers.Tests` project with 17 tests
- Wired analyzer into `Abies.csproj` for NuGet packaging (`analyzers/dotnet/cs/` convention)
- Added explicit analyzer `ProjectReference` to `Abies.Conduit.csproj` (needed for solution-level consumers)
- Added both projects to `Abies.sln`
- **Fixed all 6 ABIES001 violations** in the Conduit app (added `alt` attributes to profile/avatar images in `Profile.cs`, `Article.cs`, `Home.cs`)
- Created ADR-021 documenting the decision to use analyzers over the typed DSL
- Updated ADR index

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

None — analyzers are compile-time only and have no runtime impact.

## 📋 Additional Context

### MSBuild Discovery
`OutputItemType="Analyzer"` does **not** propagate transitively through `ProjectReference` chains. This means solution-level consumers (like `Abies.Conduit`) need an explicit `ProjectReference` to `Abies.Analyzers`, while NuGet package consumers get the analyzer automatically via the `analyzers/dotnet/cs/` convention.

### Architecture
```
Abies.Analyzers/                      # netstandard2.0, Roslyn 4.8.0
├── DiagnosticDescriptors.cs          # ABIES001–ABIES005 definitions
├── HtmlSpec.cs                       # HTML content model data
├── AnalysisHelpers.cs                # Shared semantic model utilities
├── MissingAttributeAnalyzer.cs       # ABIES001, ABIES003–ABIES005
└── ContentModelAnalyzer.cs           # ABIES002

Abies.Analyzers.Tests/                # net10.0, xUnit
├── AbiesStubs.cs                     # Minimal type stubs for testing
├── MissingAttributeAnalyzerTests.cs  # 12 tests
└── ContentModelAnalyzerTests.cs      # 5 tests
```