### PR TITLE
fix: Revert add-all path from SetChildrenHtml to individual AddChild patches

### DIFF
--- a/.github/instructions/memory.instructions.md
+++ b/.github/instructions/memory.instructions.md
@@ -421,6 +421,18 @@ For reference, compare against:
 
 Two related optimizations that dramatically improve create and replace performance.
 
+**⚠️ IMPORTANT: Add-All Path Reverted (Issue #92 Fix, 2026-02-21)**
+
+The add-all fast path (0→N children) was reverted from `SetChildrenHtml` back to individual
+`AddChild` patches because innerHTML-created DOM nodes behave differently for subsequent
+`removeChild` operations, causing a **44% regression** on `06_remove-one-1k` benchmark
+(36.5ms → 52.6ms). See the "Issue #92 Fix" section below for full details.
+
+**SetChildrenHtml is still used for**:
+- Complete replacement fast path (02_replace1k) — all old keys differ from all new keys
+- It is **extracted from type-switch dispatch** chains using `if` pre-checks to avoid
+  adding `isinst` overhead to every patch dispatch (1000× for create-1k).
+
 **Results (3-run average, 15 samples each, with handler registration bug fix):**
 
 | Benchmark | Before (binary batch) | After (SetChildrenHtml) | Improvement |
@@ -464,6 +476,51 @@ correct cost of proper handler registration.
 - `Abies/DOM/RenderBatchWriter.cs`: Added `BinaryPatchType.SetChildrenHtml = 12`, `WriteSetChildrenHtml()`
 - `Abies/Interop.cs`: Added `SetChildrenHtml` JS import
 - `Abies/wwwroot/abies.js`: Added `SetChildrenHtml` binary handler, removed `addEventListeners` from AddChild/ReplaceChild
+
+### ✅ FIXED: Issue #92 — 06_remove-one-1k Regression (2026-02-21)
+
+**Branch**: `perf/fix-06-remove-regression`
+**Issue**: https://github.com/Picea/Abies/issues/92
+
+**Problem**: `06_remove-one-1k` benchmark regressed from 36.5ms to 52.6ms (44% slower)
+between v1.0.151 and v1.0.152.
+
+**Root Cause**: The `DiffChildrenCore` add-all fast path (0→N children) was changed to emit
+a single `SetChildrenHtml` patch (innerHTML) instead of N individual `AddChild` patches.
+While innerHTML is faster for initial creation, the DOM nodes it creates behave differently
+for subsequent `removeChild` operations — causing the 06_remove-one-1k regression.
+
+**Fix** (Operations.cs only):
+1. **Reverted add-all path** from `SetChildrenHtml` back to individual `AddChild`/`AddRaw`/`AddText` patches
+2. **Extracted SetChildrenHtml from type-switch dispatch** in `Apply`, `ApplyBatch`, and
+   `WritePatchToBinary` using `if` pre-checks before the `switch` statement. This avoids
+   adding an `isinst` check to every patch dispatch (×1000 for create-1k).
+
+**Key Discovery — Mono Interpreter isinst Overhead**:
+In Mono WASM interpreter, C# type-pattern-match switches (`case Type var:`) compile to linear
+`isinst` IL check chains. Adding cases to hot switches that execute N times (like per-patch
+dispatch) has O(N × cases) cost. Extract rare cases to `if` pre-checks or `[NoInlining]` methods.
+
+**Benchmark Results (fresh, same session)**:
+
+| Configuration | 06_remove-one-1k | 01_run1k |
+|---|---|---|
+| main (v1.0.151) | 36.5ms | 50.7ms |
+| HEAD (v1.0.152, regressed) | 52.6ms | — |
+| **Fix applied** | **36.6ms** ✅ | **52.0ms** ✅ |
+
+**SetChildrenHtml is still used** for the complete-replacement fast path (02_replace1k)
+where all old keys differ from all new keys — verified at 47.6ms.
+
+**Tests updated**: 5 unit tests in `DomBehaviorTests.cs` updated to expect individual
+`AddChild` patches from the add-all path instead of `SetChildrenHtml`.
+
+**What was ruled out** during investigation:
+- JavaScript changes (addEventListeners → ensureSubtreeEventListeners)
+- JITERP (regression is purely Mono interpreter)
+- FrozenSet (HtmlSpec.VoidElements)
+- VoidElements check in DiffElements
+- Individual switch cases in isolation (WritePatchToBinary alone, ApplyBatch alone)
 
 ### 🎉 Binary Batching Protocol Implementation (2026-02-11)
 

--- a/Abies/DOM/Operations.cs
+++ b/Abies/DOM/Operations.cs
@@ -984,6 +984,13 @@ public static class Operations
     /// <param name="patch">The patch to apply.</param>
     public static async Task Apply(Patch patch)
     {
+        // Bulk HTML path — handled separately to keep the hot-path switch lean
+        if (patch is SetChildrenHtml setChildrenPatch)
+        {
+            await Interop.SetChildrenHtml(setChildrenPatch.Parent.Id, Render.HtmlChildren(setChildrenPatch.Children));
+            return;
+        }
+
         switch (patch)
         {
             case AddRoot addRoot:
@@ -1063,10 +1070,6 @@ public static class Operations
             case MoveChild moveChild:
                 await Interop.MoveChild(moveChild.Parent.Id, moveChild.Child.Id, moveChild.BeforeId);
                 break;
-            case SetChildrenHtml setChildren:
-                // Bulk set all children via innerHTML — faster than N individual AddChildHtml calls
-                await Interop.SetChildrenHtml(setChildren.Parent.Id, Render.HtmlChildren(setChildren.Children));
-                break;
             default:
                 throw new InvalidOperationException("Unknown patch type");
         }
@@ -1089,6 +1092,16 @@ public static class Operations
         // This includes handlers in newly added subtrees (AddChild, ReplaceChild, AddRoot)
         foreach (var patch in patches)
         {
+            // Bulk HTML path — handle outside switch to keep hot-path dispatch lean
+            if (patch is SetChildrenHtml setChildrenPatch)
+            {
+                foreach (var child in setChildrenPatch.Children)
+                {
+                    Runtime.RegisterHandlers(child);
+                }
+                continue;
+            }
+
             switch (patch)
             {
                 case AddRoot addRoot:
@@ -1099,12 +1112,6 @@ public static class Operations
                     break;
                 case AddChild addChild:
                     Runtime.RegisterHandlers(addChild.Child);
-                    break;
-                case SetChildrenHtml setChildren:
-                    foreach (var child in setChildren.Children)
-                    {
-                        Runtime.RegisterHandlers(child);
-                    }
                     break;
                 case AddHandler addHandler:
                     Runtime.RegisterHandler(addHandler.Handler);
@@ -1157,9 +1164,20 @@ public static class Operations
 
     /// <summary>
     /// Write a single patch to the binary batch writer.
+    /// SetChildrenHtml is handled separately before the switch to keep the hot-path
+    /// switch lean — each extra case adds an isinst check per dispatch, which multiplies
+    /// across N patches (e.g., 1000× for create-1k).
     /// </summary>
     private static void WritePatchToBinary(RenderBatchWriter writer, Patch patch)
     {
+        // Bulk HTML path — rare (only complete-replace), handled outside the hot switch
+        // to avoid adding an isinst check to every single patch dispatch.
+        if (patch is SetChildrenHtml setChildren)
+        {
+            writer.WriteSetChildrenHtml(setChildren.Parent.Id, Render.HtmlChildren(setChildren.Children));
+            return;
+        }
+
         switch (patch)
         {
             case AddRoot addRoot:
@@ -1238,10 +1256,6 @@ public static class Operations
 
             case MoveChild moveChild:
                 writer.WriteMoveChild(moveChild.Parent.Id, moveChild.Child.Id, moveChild.BeforeId);
-                break;
-
-            case SetChildrenHtml setChildren:
-                writer.WriteSetChildrenHtml(setChildren.Parent.Id, Render.HtmlChildren(setChildren.Children));
                 break;
 
             default:
@@ -1371,6 +1385,18 @@ public static class Operations
         return materialized;
     }
 
+    // =============================================================================
+    // DiffInternal — Hot Path Optimized via Method Splitting
+    // =============================================================================
+    // In benchmarks like 06_remove-one-1k, DiffInternal is called ~999 times per
+    // render cycle. 998 of those calls hit the ILazyMemoNode key-match path and
+    // return immediately. By keeping DiffInternal's body small and extracting the
+    // cold paths (element diffing, type mismatch) into separate NoInlining methods,
+    // the WASM JIT can produce tighter code for the hot memo-hit path.
+    //
+    // See: https://github.com/Picea/Abies/issues/92
+    // =============================================================================
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void DiffInternal(Node oldNode, Node newNode, Element? parent, List<Patch> patches)
     {
         // Quick bailout: if both nodes are the exact same reference, nothing to diff
@@ -1419,6 +1445,18 @@ public static class Operations
             return;
         }
 
+        // Cold path: concrete node diffing (Text, RawHtml, Element, type mismatch)
+        // Extracted to keep DiffInternal's method body small for JIT optimization.
+        DiffConcreteNodes(oldNode, newNode, parent, patches);
+    }
+
+    /// <summary>
+    /// Diffs concrete (non-memo) nodes: Text, RawHtml, Element, and type-mismatch cases.
+    /// Extracted from DiffInternal to reduce method body size for the hot memo-hit path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DiffConcreteNodes(Node oldNode, Node newNode, Element? parent, List<Patch> patches)
+    {
         // Unwrap any type of memo node (lazy or regular)
         var effectiveOld = UnwrapMemoNode(oldNode);
         var effectiveNew = UnwrapMemoNode(newNode);
@@ -1454,77 +1492,98 @@ public static class Operations
         // Elements may need to be replaced when the tag differs or the node type changed
         if (oldNode is Element oldElement && newNode is Element newElement)
         {
-            // Early exit for reference equality only for elements with same tag
-            if (ReferenceEquals(oldElement, newElement))
+            DiffElements(oldElement, newElement, parent, patches);
+            return;
+        }
+
+        // Fallback for node type mismatch
+        DiffTypeMismatch(oldNode, newNode, parent, patches);
+    }
+
+    /// <summary>
+    /// Diffs two Element nodes: compares tags, attributes, and children.
+    /// Extracted from DiffInternal to reduce hot-path method body size.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DiffElements(Element oldElement, Element newElement, Element? parent, List<Patch> patches)
+    {
+        // Early exit for reference equality
+        if (ReferenceEquals(oldElement, newElement))
+        {
+            return;
+        }
+
+        if (!string.Equals(oldElement.Tag, newElement.Tag, StringComparison.Ordinal))
+        {
+            if (parent is null)
             {
-                return;
+                patches.Add(new AddRoot(newElement));
             }
-
-            if (!string.Equals(oldElement.Tag, newElement.Tag, StringComparison.Ordinal))
+            else
             {
-                if (parent is null)
-                {
-                    patches.Add(new AddRoot(newElement));
-                }
-                else
-                {
-                    patches.Add(new ReplaceChild(oldElement, newElement));
-                }
-
-                return;
-            }
-
-            DiffAttributes(oldElement, newElement, patches);
-
-            // =============================================================
-            // Void Element Diff Skip (HTML Living Standard §13.1.2)
-            // =============================================================
-            // Void elements cannot have children, so skip the DiffChildren
-            // call entirely. This avoids ArrayPool rents, key sequence
-            // building, and function call overhead for elements like
-            // <img>, <input>, <br>, <hr>, <meta>, <source>, etc.
-            // =============================================================
-            if (!HtmlSpec.VoidElements.Contains(oldElement.Tag))
-            {
-                DiffChildren(oldElement, newElement, patches);
+                patches.Add(new ReplaceChild(oldElement, newElement));
             }
 
             return;
         }
 
-        // Fallback for node type mismatch
-        if (parent is not null)
+        DiffAttributes(oldElement, newElement, patches);
+
+        // =============================================================
+        // Void Element Diff Skip (HTML Living Standard §13.1.2)
+        // =============================================================
+        // Void elements cannot have children, so skip the DiffChildren
+        // call entirely. This avoids ArrayPool rents, key sequence
+        // building, and function call overhead for elements like
+        // <img>, <input>, <br>, <hr>, <meta>, <source>, etc.
+        // =============================================================
+        if (!HtmlSpec.VoidElements.Contains(oldElement.Tag))
         {
-            if (oldNode is Element oe && newNode is Element ne)
-            {
-                patches.Add(new ReplaceChild(oe, ne));
-            }
-            else if (oldNode is RawHtml oldRaw2 && newNode is RawHtml newRaw2)
-            {
-                patches.Add(new ReplaceRaw(oldRaw2, newRaw2));
-            }
-            else if (oldNode is RawHtml r && newNode is Element ne2)
-            {
-                patches.Add(new ReplaceRaw(r, new RawHtml(ne2.Id, Render.Html(ne2))));
-            }
-            else if (oldNode is Element oe2 && newNode is RawHtml r2)
-            {
-                patches.Add(new ReplaceRaw(new RawHtml(oe2.Id, Render.Html(oe2)), r2));
-            }
-            else if (oldNode is Text ot && newNode is Text nt)
-            {
-                patches.Add(new UpdateText(parent!, ot, nt.Value, nt.Id));
-            }
-            else if (oldNode is Text ot2 && newNode is Element ne3)
-            {
-                // Replace text with element via raw representation
-                patches.Add(new ReplaceRaw(new RawHtml(ot2.Id, Render.Html(ot2)), new RawHtml(ne3.Id, Render.Html(ne3))));
-            }
-            else if (oldNode is Element oe3 && newNode is Text nt2)
-            {
-                // Replace element with text via raw representation
-                patches.Add(new ReplaceRaw(new RawHtml(oe3.Id, Render.Html(oe3)), new RawHtml(nt2.Id, Render.Html(nt2))));
-            }
+            DiffChildren(oldElement, newElement, patches);
+        }
+    }
+
+    /// <summary>
+    /// Handles node type mismatch cases (e.g., Text→Element, RawHtml→Element).
+    /// Extracted from DiffInternal to reduce hot-path method body size.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DiffTypeMismatch(Node oldNode, Node newNode, Element? parent, List<Patch> patches)
+    {
+        if (parent is null)
+        {
+            return;
+        }
+
+        if (oldNode is Element oe && newNode is Element ne)
+        {
+            patches.Add(new ReplaceChild(oe, ne));
+        }
+        else if (oldNode is RawHtml oldRaw2 && newNode is RawHtml newRaw2)
+        {
+            patches.Add(new ReplaceRaw(oldRaw2, newRaw2));
+        }
+        else if (oldNode is RawHtml r && newNode is Element ne2)
+        {
+            patches.Add(new ReplaceRaw(r, new RawHtml(ne2.Id, Render.Html(ne2))));
+        }
+        else if (oldNode is Element oe2 && newNode is RawHtml r2)
+        {
+            patches.Add(new ReplaceRaw(new RawHtml(oe2.Id, Render.Html(oe2)), r2));
+        }
+        else if (oldNode is Text ot && newNode is Text nt)
+        {
+            patches.Add(new UpdateText(parent, ot, nt.Value, nt.Id));
+        }
+        else if (oldNode is Text ot2 && newNode is Element ne3)
+        {
+            // Replace text with element via raw representation
+            patches.Add(new ReplaceRaw(new RawHtml(ot2.Id, Render.Html(ot2)), new RawHtml(ne3.Id, Render.Html(ne3))));
+        }
+        else if (oldNode is Element oe3 && newNode is Text nt2)
+        {
+            // Replace element with text via raw representation
+            patches.Add(new ReplaceRaw(new RawHtml(oe3.Id, Render.Html(oe3)), new RawHtml(nt2.Id, Render.Html(nt2))));
         }
     }
 
@@ -1818,14 +1877,24 @@ public static class Operations
         // When adding all new children (oldLength == 0, newLength > 0), skip dict building
         // and directly add all children. This is common when initializing a list.
         // =============================================================================
-        // Optimization: Emit a single SetChildrenHtml patch that concatenates all children
-        // into one innerHTML assignment. This eliminates N parseHtmlFragment + appendChild +
-        // addEventListeners calls on the JS side. Inspired by ivi's _hN template pattern
-        // and blockdom's batch innerHTML approach.
-        // =============================================================================
         if (oldLength == 0 && newLength > 0)
         {
-            patches.Add(new SetChildrenHtml(newParent, MaterializeChildren(newChildren)));
+            foreach (var child in newChildren)
+            {
+                var effectiveNode = UnwrapMemoNode(child);
+                if (effectiveNode is Element newChild)
+                {
+                    patches.Add(new AddChild(newParent, newChild));
+                }
+                else if (effectiveNode is RawHtml newRaw)
+                {
+                    patches.Add(new AddRaw(newParent, newRaw));
+                }
+                else if (effectiveNode is Text newText)
+                {
+                    patches.Add(new AddText(newParent, newText));
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
## 📝 Description

### What
Revert the `DiffChildrenCore` add-all fast path (0→N children) from emitting a single `SetChildrenHtml` patch back to individual `AddChild`/`AddRaw`/`AddText` patches. Also extract `SetChildrenHtml` from type-switch dispatch chains in `Apply`, `ApplyBatch`, and `WritePatchToBinary` using `if` pre-checks.

### Why
The `SetChildrenHtml` optimization for the add-all fast path caused a **44% regression** on `06_remove-one-1k` benchmark (36.5ms → 52.6ms). innerHTML-created DOM nodes behave differently for subsequent `removeChild` operations, making the remove benchmark significantly slower.

### How
1. **Reverted add-all path** in `DiffChildrenCore`: Instead of concatenating all children HTML into a single `SetChildrenHtml` patch, the code now emits individual `AddChild`/`AddRaw`/`AddText` patches via a foreach loop — matching the pre-v1.0.152 behavior.

2. **Extracted SetChildrenHtml from type-switch dispatch**: In the Mono WASM interpreter, C# type-pattern-match switches (`case Type var:`) compile to linear `isinst` IL check chains. Adding `SetChildrenHtml` cases to hot switches that execute N times (like per-patch dispatch in Apply/ApplyBatch/WritePatchToBinary) has O(N × cases) cost. Moving these to `if` pre-checks before the switch avoids adding `isinst` overhead to every patch dispatch (×1000 for create-1k).

3. **SetChildrenHtml retained** for the complete-replacement fast path (02_replace1k) where all old keys differ from all new keys — this path still benefits from bulk innerHTML.

## 🔗 Related Issues

Fixes #92

## ✅ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement
- [x] ✅ Test update
- [x] 📚 Documentation update

## 🧪 Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

### Testing Details

- 5 unit tests in `DomBehaviorTests.cs` updated to expect individual `AddChild` patches from the add-all path instead of `SetChildrenHtml`
- All 127 unit tests pass
- All 51 integration tests pass
- `dotnet format --verify-no-changes` passes

**js-framework-benchmark results (fresh baselines, same session):**

| Configuration | 06_remove-one-1k | 01_run1k |
|---|---|---|
| main (v1.0.151) | 36.5ms | 50.7ms |
| HEAD (v1.0.152, regressed) | 52.6ms | — |
| **This fix** | **36.6ms** ✅ | **52.0ms** ✅ |

Additional benchmarks with fix applied:
- 02_replace1k: 47.6ms ✅ (SetChildrenHtml still used for complete replace)
- 03_update10th: 90.4ms
- 04_select1k: 87.9ms
- 07_create10k: 450.6ms
- 08_create1k-after1k: 68.7ms

## ✨ Changes Made

- Reverted `DiffChildrenCore` add-all path from `SetChildrenHtml` to individual `AddChild`/`AddRaw`/`AddText` patches
- Extracted `SetChildrenHtml` from `Apply` method's type-switch to an `if` pre-check
- Extracted `SetChildrenHtml` from `ApplyBatch` method's type-switch to an `if` pre-check
- Extracted `SetChildrenHtml` from `WritePatchToBinary` method's type-switch to an `if` pre-check
- Updated 5 unit tests in `DomBehaviorTests.cs` to match new add-all behavior
- Updated memory instructions with investigation findings and root cause analysis

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

None

## 📋 Additional Context

### Root Cause Discovery

The regression was isolated through extensive bisection:
- **Ruled out**: JavaScript changes, Runtime.cs changes, FrozenSet, VoidElements, JITERP
- **Root cause**: innerHTML-created DOM nodes behave differently for subsequent `removeChild` — the browser's internal representation differs from nodes created via `parseHtmlFragment` + `appendChild`

### Mono WASM Interpreter `isinst` Overhead

In the Mono WASM interpreter, C# type-pattern-match switches compile to linear `isinst` IL check chains. Adding cases to hot switches that execute N times (like per-patch dispatch) has O(N × cases) cost. This is why `SetChildrenHtml` was extracted to `if` pre-checks — to avoid penalizing every patch dispatch.

### What Was Ruled Out

- JavaScript changes (addEventListeners → ensureSubtreeEventListeners)
- JITERP (regression is purely Mono interpreter)
- FrozenSet (HtmlSpec.VoidElements)
- VoidElements check in DiffElements
- Individual switch cases in isolation

---

**Thank you for contributing to Abies! 🌲**