### PR TITLE
docs: Document shared-memory protocol investigation and benchmark power state awareness

### DIFF
--- a/docs/adr/ADR-011-javascript-interop.md
+++ b/docs/adr/ADR-011-javascript-interop.md
@@ -181,6 +181,73 @@ Rejected to keep framework minimal and focused.
 - [ADR-005: WebAssembly Runtime](./ADR-005-webassembly-runtime.md)
 - [ADR-007: Subscription Model](./ADR-007-subscriptions.md)
 
+## Amendments
+
+### Amendment 1: Binary Batching Protocol (2026-02-11)
+
+**Status:** Accepted
+
+DOM patch operations originally used individual `[JSImport]` calls per patch (e.g., `AddChildHtml`,
+`RemoveChild`). Profiling revealed that per-call JS interop overhead dominated for batch operations
+like creating 1000 rows.
+
+**Decision:** Batch all patches into a single binary buffer and transfer in one interop call.
+
+**Implementation:**
+- `RenderBatchWriter.cs`: Writes patches into a binary format (header + fixed-size entries + LEB128 string table)
+- `[JSMarshalAs<JSType.MemoryView>] Span<byte>`: Transfers the buffer via zero-copy memory view
+- `abies.js`: Binary reader using `DataView` API decodes and applies all patches
+
+**Result:** 17% improvement on create 1000 rows benchmark (107ms → 89ms), matching Blazor WASM.
+
+Individual `[JSImport]` calls are retained as fallback for non-batched operations (navigation, storage).
+
+### Amendment 2: Shared-Memory Protocol — Rejected (2026-02-19)
+
+**Status:** Rejected
+
+**Hypothesis:** The `JSType.MemoryView` wrapper calls `slice()` to copy the binary buffer into a
+new `Uint8Array`. Eliminating this copy via Blazor-style shared WASM memory access would improve
+batch apply performance.
+
+**Implementation (branch `perf/shared-memory-protocol`):**
+
+```text
+Before (MemoryView):
+  C# Span<byte> → JSType.MemoryView wrapper → JS calls slice() → Uint8Array copy → read patches
+
+After (Shared Memory):
+  C# unsafe fixed pin → pass (address, length) → JS reads WASM heap directly → zero-copy view
+```
+
+- Changed `ApplyBinaryBatch` from `[JSMarshalAs<JSType.MemoryView>] Span<byte>` to `(int address, int length)`
+- C# pins buffer with `unsafe fixed`, passes raw pointer as int
+- JS uses `globalThis.getDotnetRuntime(0).localHeapViewU8()` to access WASM linear memory
+- Creates `new Uint8Array(heap.buffer, address, length)` — zero-copy view, no `slice()`
+
+**A/B Benchmark Results (same session, same power state):**
+
+| Benchmark     | MemoryView | Shared Memory | Δ              |
+| ------------- | ---------- | ------------- | -------------- |
+| 01_run1k      | 70.7ms     | 71.7ms        | +1.4% (noise)  |
+| 02_replace1k  | 79.9ms     | 80.0ms        | +0.1% (noise)  |
+| 07_create10k  | 819.0ms    | 815.5ms       | −0.4% (noise)  |
+
+**Result:** Zero measurable improvement across all benchmarks.
+
+**Why:** The `slice()` copy cost for a ~16 KB buffer (1000 rows) is negligible (~microseconds).
+The real costs are VDOM diffing (~40ms) and DOM operations (~20ms). Eliminating a
+microsecond-level copy cannot produce measurable E2E improvement.
+
+**Conclusion:** `JSType.MemoryView` remains the transfer mechanism. Do not pursue further interop
+protocol optimizations — the remaining performance gap with Blazor is in VDOM rebuild cost
+(architectural), not JS interop overhead.
+
+**Revisit if:** The architecture changes in a way that significantly increases batch buffer sizes
+(e.g., a component model that batches across multiple subtrees, or a hybrid approach that sends
+larger diffs less frequently). At that point the `slice()` copy cost may become measurable and
+the shared-memory protocol should be re-evaluated.
+
 ## References
 
 - [.NET WASM JavaScript Interop](https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability)


### PR DESCRIPTION
## 📝 Description

### What
Documents the shared-memory binary protocol investigation (issue #93) and adds benchmark power state awareness guidelines.

### Why
- The shared-memory protocol was implemented and A/B tested against main, revealing **zero measurable improvement** — all apparent differences were caused by comparing benchmarks across different power states (plugged in vs battery)
- This power state confound is a critical lesson for future benchmarking on the M4 Pro MacBook (up to 33% variance)
- The investigation results and decision rationale need to be preserved for future reference

### How
- Added power state awareness section to `memory.instructions.md` with reference values and rules
- Added ADR-011 amendments documenting both the binary batching acceptance and the shared-memory protocol rejection
- Included "Revisit if" clause for future architecture changes that might make shared-memory worthwhile
- **Code changes were reverted** — only documentation remains on this branch

## 🔗 Related Issues

Closes #93

## ✅ Type of Change

- [x] 📚 Documentation update
- [x] ⚡ Performance improvement

## 🧪 Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing performed

### Testing Details

- Full shared-memory implementation was built and passed all 127 unit tests
- A/B benchmarked against main in same session (battery): zero measurable difference across all 6 benchmarks
- Code reverted; build and all 127 tests verified passing after revert

## ✨ Changes Made

- Added "⚠️ Benchmark Environment: Power State Awareness" section to `memory.instructions.md` with reference values showing up to 33% variance between power states
- Added "❌ REJECTED: Shared-Memory Binary Protocol" section documenting A/B test results
- Added ADR-011 Amendment 1: Binary Batching Protocol (accepted, already shipped)
- Added ADR-011 Amendment 2: Shared-Memory Protocol (rejected, with "Revisit if" clause)
- Reverted all shared-memory code changes (Interop.cs, Operations.cs, abies.js) back to MemoryView approach

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Comments added for complex/non-obvious code
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

None — documentation only.

## 📋 Additional Context

### Key Finding: Power State Confound

The shared-memory protocol initially appeared to show both improvements AND regressions when compared across sessions. A/B testing against `main` on the same machine in the same session revealed **zero measurable difference** — all variance was from comparing plugged-in vs battery sessions.

| Benchmark | Main (MemoryView) | Shared Memory | Δ |
|---|---|---|---|
| 01_run1k | 70.7ms | 71.7ms | +1.4% (noise) |
| 02_replace1k | 79.9ms | 80.0ms | +0.1% (noise) |
| 09_clear1k | 92.3ms | 92.4ms | +0.1% (noise) |

### Why It Didn't Help

The `slice()` copy cost for a ~16KB buffer (1000 rows) is **negligible** (~microseconds). The real costs are VDOM diffing (~40ms) and DOM operations (~20ms). Eliminating a microsecond-level copy cannot produce measurable E2E improvement.

---

**Thank you for contributing to Abies! 🌲**