### PR TITLE
revert: Undo add-all path revert from SetChildrenHtml to individual AddChild patches

### DIFF
--- a/Abies.Tests/DomBehaviorTests.cs
+++ b/Abies.Tests/DomBehaviorTests.cs
@@ -604,8 +604,7 @@ public class DomBehaviorTests
         // This simulates the benchmark scenario:
         // 1. Initial render: tbody with no children
         // 2. After "Create 1000 rows": tbody with 1000 memo-wrapped children
-        // The add-all path emits individual AddChild patches (not SetChildrenHtml)
-        // to avoid innerHTML-induced DOM layout differences that regress 06_remove-one-1k.
+        // Optimization: emits a single SetChildrenHtml patch instead of N AddChild patches
         var emptyTbody = new Element("tbody-1", "tbody", []);
 
         var row1 = new Element("row-1", "tr", [], new Text("t-1", "Row 1"));
@@ -616,15 +615,15 @@ public class DomBehaviorTests
 
         var patches = Operations.Diff(emptyTbody, filledTbody);
 
-        // Should have individual AddChild patches for each child
+        // Should have a single SetChildrenHtml patch (bulk innerHTML)
         Assert.NotEmpty(patches);
-        Assert.Equal(2, patches.OfType<AddChild>().Count());
+        Assert.Contains(patches, p => p is SetChildrenHtml);
     }
 
     [Fact]
     public void MemoNode_InsertChildPatch_ShouldContainCachedContent()
     {
-        // Verify that the add-all path emits AddChild patches for each child
+        // Verify that SetChildrenHtml patches contain all the children
         var emptyTbody = new Element("tbody-1", "tbody", []);
 
         var row = new Element("row-1", "tr", [], new Text("t-1", "Hello"));
@@ -633,13 +632,15 @@ public class DomBehaviorTests
 
         var patches = Operations.Diff(emptyTbody, filledTbody);
 
-        // Should have an AddChild patch for the memo-wrapped row
-        var addChildPatches = patches.OfType<AddChild>().ToList();
-        Assert.Single(addChildPatches);
-        var patch = addChildPatches[0];
+        // Find the SetChildrenHtml patch
+        var setChildrenPatches = patches.OfType<SetChildrenHtml>().ToList();
+        Assert.Single(setChildrenPatches);
+        var patch = setChildrenPatches[0];
 
         // The parent should be the tbody
         Assert.Equal("tbody-1", patch.Parent.Id);
+        // The children should include the memo-wrapped row
+        Assert.Single(patch.Children);
     }
 
     #endregion
@@ -647,12 +648,10 @@ public class DomBehaviorTests
     #region SetChildrenHtml Batch Optimization Tests
 
     [Fact]
-    public void SetChildrenHtml_EmptyToMultipleChildren_EmitsIndividualAddChildPatches()
+    public void SetChildrenHtml_EmptyToMultipleChildren_EmitsSinglePatch()
     {
-        // Verify that going from 0→N children emits N individual AddChild patches
-        // (not SetChildrenHtml). The add-all path was reverted to individual patches
-        // because innerHTML-created DOM behaves differently for subsequent removeChild,
-        // causing a regression on 06_remove-one-1k benchmark.
+        // Verify that going from 0→N children emits ONE SetChildrenHtml patch
+        // instead of N individual AddChild patches.
         var emptyParent = new Element("list-1", "ul", []);
 
         var children = Enumerable.Range(1, 100).Select(i =>
@@ -662,9 +661,11 @@ public class DomBehaviorTests
 
         var patches = Operations.Diff(emptyParent, filledParent);
 
-        // Should emit 100 individual AddChild patches (not SetChildrenHtml)
-        Assert.Equal(100, patches.OfType<AddChild>().Count());
-        Assert.DoesNotContain(patches, p => p is SetChildrenHtml);
+        // Should emit exactly ONE SetChildrenHtml patch, not 100 AddChild patches
+        var setChildrenPatches = patches.OfType<SetChildrenHtml>().ToList();
+        Assert.Single(setChildrenPatches);
+        Assert.Equal(100, setChildrenPatches[0].Children.Length);
+        Assert.Equal("list-1", setChildrenPatches[0].Parent.Id);
     }
 
     [Fact]
@@ -699,17 +700,16 @@ public class DomBehaviorTests
     }
 
     [Fact]
-    public void SetChildrenHtml_EmptyToSingleChild_EmitsAddChildPatch()
+    public void SetChildrenHtml_EmptyToSingleChild_EmitsSinglePatch()
     {
-        // A single new child should use AddChild (add-all path uses individual patches)
+        // Even a single new child should use SetChildrenHtml (consistent path)
         var emptyParent = new Element("p-1", "div", []);
         var child = new Element("c-1", "span", [], new Text("t-1", "Only"));
         var filledParent = new Element("p-1", "div", [], child);
 
         var patches = Operations.Diff(emptyParent, filledParent);
 
-        Assert.Single(patches.OfType<AddChild>());
-        Assert.DoesNotContain(patches, p => p is SetChildrenHtml);
+        Assert.Single(patches.OfType<SetChildrenHtml>());
     }
 
     [Fact]
@@ -773,11 +773,12 @@ public class DomBehaviorTests
     }
 
     [Fact]
-    public void SetChildrenHtml_LazyMemoWithHandler_AddAllPathUnwrapsMemoNodes()
+    public void SetChildrenHtml_LazyMemoWithHandler_MaterializesChildren()
     {
-        // Regression test: The add-all path (0→N children) correctly unwraps LazyMemo
-        // nodes to their concrete Element form for AddChild patches.
-        // This ensures handlers are properly registered during ApplyBatch.
+        // Regression test: SetChildrenHtml must materialize LazyMemo children so that
+        // RegisterHandlers and Render.HtmlChildren see the SAME concrete nodes with
+        // the SAME CommandIds. Without materialization, each LazyMemo.Evaluate() call
+        // produces fresh nodes with new CommandIds, causing handler map / HTML divergence.
         var emptyTbody = new Element("tbody-1", "tbody", []);
 
         // Create LazyMemo children with click handlers (simulates benchmark rows)
@@ -794,12 +795,36 @@ public class DomBehaviorTests
 
         var patches = Operations.Diff(emptyTbody, filledTbody);
 
-        // Should emit individual AddChild patches (add-all path)
-        var addChildPatches = patches.OfType<AddChild>().ToList();
-        Assert.Equal(2, addChildPatches.Count);
+        // Should emit a single SetChildrenHtml patch
+        var setChildrenPatches = patches.OfType<SetChildrenHtml>().ToList();
+        Assert.Single(setChildrenPatches);
+        var patch = setChildrenPatches[0];
 
-        // Children should be unwrapped Elements (not LazyMemo wrappers)
-        Assert.All(addChildPatches, p => Assert.IsType<Element>(p.Child));
+        // Children should be materialized (concrete Elements, not LazyMemo wrappers)
+        Assert.Equal(2, patch.Children.Length);
+        Assert.All(patch.Children, child => Assert.IsType<Element>(child));
+
+        // Verify that rendering the same children twice produces identical HTML
+        // (proves materialization: no double-evaluation with divergent CommandIds)
+        var html1 = Render.HtmlChildren(patch.Children);
+        var html2 = Render.HtmlChildren(patch.Children);
+        Assert.Equal(html1, html2);
+
+        // Verify event attributes are present in the rendered HTML
+        Assert.Contains("data-event-click", html1);
+
+        // Verify CachedNode backfill: the original LazyMemo wrappers in the parent's
+        // children array should now have CachedNode populated. This is essential for
+        // UnregisterHandlers to traverse the cached content when cleaning up handlers.
+        var parentChildren = filledTbody.Children;
+        for (int i = 0; i < parentChildren.Length; i++)
+        {
+            var child = parentChildren[i];
+            Assert.IsAssignableFrom<ILazyMemoNode>(child);
+            var lazyChild = (ILazyMemoNode)child;
+            Assert.NotNull(lazyChild.CachedNode);
+            Assert.IsType<Element>(lazyChild.CachedNode);
+        }
     }
 
     #endregion


### PR DESCRIPTION
## 📝 Description

### What
Reverts commit 81548ba ("fix: revert add-all path from SetChildrenHtml to individual AddChild patches").

### Why
The original commit reverted the SetChildrenHtml add-all fast path due to a reported 44% regression on `06_remove-one-1k`. After further analysis, this revert needs to be undone — restoring the SetChildrenHtml optimization for the add-all path (0→N children).

### How
Standard `git revert` of commit `81548bae5e13548b3169efff67b5d2e98ccbd85b`. Restores the previous state of:
- `Abies/DOM/Operations.cs` — SetChildrenHtml add-all fast path
- `Abies.Tests/DomBehaviorTests.cs` — corresponding test expectations
- `.github/instructions/memory.instructions.md` — memory notes

## 🔗 Related Issues

Reverts the fix for #92

## ✅ Type of Change

- [x] ⚡ Performance improvement
- [x] ✅ Test update

## 🧪 Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing performed

### Testing Details

- All 164 unit tests pass after revert
- Build succeeds with 0 warnings

## ✨ Changes Made

- Reverted `Operations.cs` to restore SetChildrenHtml for add-all fast path
- Reverted `DomBehaviorTests.cs` test expectations
- Reverted memory instructions changes

## 🔍 Code Review Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All commits follow Conventional Commits format
- [x] Branch is up-to-date with main
- [x] No merge conflicts

## 🚀 Deployment Notes

None

## 📋 Additional Context

This is a clean `git revert` — no manual edits.