### PR TITLE
fix: Add Picea.Abies.Server.Kestrel to CD pack steps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,9 @@ jobs:
     - name: Pack Picea.Abies.Server
       if: github.event_name != 'pull_request'
       run: dotnet pack ./Picea.Abies.Server/Picea.Abies.Server.csproj --configuration Release --output ./nupkg /p:PackageVersion=${{ steps.version.outputs.VERSION }}
+    - name: Pack Picea.Abies.Server.Kestrel
+      if: github.event_name != 'pull_request'
+      run: dotnet pack ./Picea.Abies.Server.Kestrel/Picea.Abies.Server.Kestrel.csproj --configuration Release --output ./nupkg /p:PackageVersion=${{ steps.version.outputs.VERSION }}
     - name: Pack Picea.Abies.Templates
       if: github.event_name != 'pull_request'
       run: dotnet pack ./Picea.Abies.Templates/Picea.Abies.Templates.csproj --configuration Release --output ./nupkg /p:PackageVersion=${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
## 📝 Description

### What
Add the missing `Pack Picea.Abies.Server.Kestrel` step to the CD workflow.

### Why
Running `dotnet new abies-server` fails with:

```
error NU1101: Unable to find package Picea.Abies.Server.Kestrel.
No packages exist with this id in source(s): nuget.org
```

The `abies-server` template references `Picea.Abies.Server.Kestrel`, but the CD pipeline never packs or publishes this package. The project exists (`Picea.Abies.Server.Kestrel/`) and is correctly configured as packable with a `PackageId`, but it was simply omitted from the workflow.

### How
Added a `Pack Picea.Abies.Server.Kestrel` step to `cd.yml`, placed after `Pack Picea.Abies.Server` (which it depends on) and before `Pack Picea.Abies.Templates` (which consumes it via the template).

## 🔗 Related Issues
Fixes the `dotnet new abies-server` NU1101 error.

## ✅ Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🧪 Testing
### Test Coverage
- [x] Verified `Picea.Abies.Server.Kestrel.csproj` is packable with correct `PackageId`
- [x] Confirmed via NuGet API that the package does not exist yet (BlobNotFound)
- [x] Confirmed `Picea.Abies.Server` and `Picea.Abies.Browser` are published (7 versions each)

### Testing Details
- Checked NuGet API: `picea.abies.server.kestrel` returns BlobNotFound
- Read template project file: correctly references `Picea.Abies.Server.Kestrel`
- Read Kestrel csproj: has `<PackageId>Picea.Abies.Server.Kestrel</PackageId>` and `<IsPackable>true</IsPackable>`

## ✨ Changes Made
- Added `Pack Picea.Abies.Server.Kestrel` step to `.github/workflows/cd.yml`

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Step follows the same pattern as all other pack steps in the workflow