### PR TITLE
fix: Ensure abies-server.js copies to output for NuGet consumers

### DIFF
--- a/Picea.Abies.Server.Kestrel/Picea.Abies.Server.Kestrel.csproj
+++ b/Picea.Abies.Server.Kestrel/Picea.Abies.Server.Kestrel.csproj
@@ -9,7 +9,7 @@
 
   <!-- Embed wwwroot as static web assets so consuming apps can serve them -->
   <ItemGroup>
-    <Content Include="wwwroot\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="wwwroot\**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" PackageFlatten="false" />
   </ItemGroup>
 
   <!-- NuGet package metadata -->


### PR DESCRIPTION
## 📝 Description

### What
Add `PackageCopyToOutput` and `PackageFlatten` metadata to the `wwwroot` Content items in `Picea.Abies.Server.Kestrel.csproj`.

### Why
When `Picea.Abies.Server.Kestrel` is consumed as a **NuGet package** (e.g. via `dotnet new abies-server`), the `abies-server.js` file is not copied to the consuming project's output directory. This causes `UseAbiesStaticFiles()` to silently fail — the `PhysicalFileProvider` can't find `wwwroot/` next to the assembly, so the static files middleware is never registered, resulting in a **404 for `/_abies/abies-server.js`**.

The file was correctly included in the `.nupkg` under `contentFiles/`, but the nuspec defaulted to `copyToOutput="false"` and `flatten="true"` — meaning the file was never copied, and even if it were, the directory structure would be lost.

**This only affects NuGet package consumers.** Project references (e.g. `Counter.Server` in this repo) work fine because `CopyToOutputDirectory="PreserveNewest"` handles the copy.

### How
Added two MSBuild metadata attributes to the existing Content item:

```xml
<Content Include="wwwroot\**" 
         CopyToOutputDirectory="PreserveNewest" 
         PackageCopyToOutput="true" 
         PackageFlatten="false" />
```

- `PackageCopyToOutput="true"` → nuspec gets `copyToOutput="true"`, so NuGet copies the file to the consuming project's output
- `PackageFlatten="false"` → nuspec gets `flatten="false"`, preserving the `wwwroot/_abies/` directory structure

### Verification

Packed the project, inspected the nuspec — confirms `copyToOutput="true" flatten="false"`:
```xml
<contentFiles>
  <files include="any/net10.0/wwwroot/_abies/abies-server.js" 
         buildAction="Content" copyToOutput="true" flatten="false" />
</contentFiles>
```

Created a temp project referencing the local `.nupkg` — confirmed `abies-server.js` appears at `bin/Release/net10.0/wwwroot/_abies/abies-server.js` ✅

## 🔗 Related Issues
Follow-up to PR #119 (which added the missing pack step to CD).

## ✅ Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🧪 Testing
### Test Coverage
- [x] Verified nuspec output contains `copyToOutput="true" flatten="false"`
- [x] Verified file appears in output directory when consumed as NuGet package
- [x] Verified project-reference scenario (Counter.Server) still works

### Testing Details
- `dotnet pack` → `unzip -p *.nupkg *.nuspec` → confirmed metadata
- Created temp `dotnet new web` project → added local package → `dotnet build` → confirmed `bin/Release/net10.0/wwwroot/_abies/abies-server.js` exists
- `dotnet build Counter.Server` → confirmed `bin/Debug/net10.0/wwwroot/_abies/abies-server.js` still present

## ✨ Changes Made
- Added `PackageCopyToOutput="true"` and `PackageFlatten="false"` to wwwroot Content items in `Picea.Abies.Server.Kestrel.csproj`

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Both NuGet package and project-reference scenarios verified