### PR TITLE
fix(conduit): Pin Picea to pre-rc3 version

### DIFF
--- a/Picea.Abies.Conduit.Api.Tests/Picea.Abies.Conduit.Api.Tests.csproj
+++ b/Picea.Abies.Conduit.Api.Tests/Picea.Abies.Conduit.Api.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Conduit.Api\Picea.Abies.Conduit.Api.csproj" />
     <ProjectReference Include="..\Picea.Abies.Conduit\Picea.Abies.Conduit.csproj" />
-    <PackageReference Include="Picea" Version="1.0.*-*" />
+    <PackageReference Include="Picea" Version="1.0.34-rc-0002" />
     <PackageReference Include="Picea.Glauca" Version="0.1.*-*" />
   </ItemGroup>
 

--- a/Picea.Abies.Conduit.Api/Picea.Abies.Conduit.Api.csproj
+++ b/Picea.Abies.Conduit.Api/Picea.Abies.Conduit.Api.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Conduit\Picea.Abies.Conduit.csproj" />
     <ProjectReference Include="..\Picea.Abies.Conduit.ReadStore.PostgreSQL\Picea.Abies.Conduit.ReadStore.PostgreSQL.csproj" />
-    <PackageReference Include="Picea" Version="1.0.*-*" />
+    <PackageReference Include="Picea" Version="1.0.34-rc-0002" />
     <PackageReference Include="Picea.Glauca" Version="0.1.*-*" />
     <PackageReference Include="Picea.Glauca.KurrentDB" Version="0.1.*-*" />
     <ProjectReference Include="..\Picea.Abies.Conduit.ServiceDefaults\Picea.Abies.Conduit.ServiceDefaults.csproj" />

--- a/Picea.Abies.Conduit.ReadStore.PostgreSQL.Tests/Picea.Abies.Conduit.ReadStore.PostgreSQL.Tests.csproj
+++ b/Picea.Abies.Conduit.ReadStore.PostgreSQL.Tests/Picea.Abies.Conduit.ReadStore.PostgreSQL.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Conduit\Picea.Abies.Conduit.csproj" />
     <ProjectReference Include="..\Picea.Abies.Conduit.ReadStore.PostgreSQL\Picea.Abies.Conduit.ReadStore.PostgreSQL.csproj" />
-    <PackageReference Include="Picea" Version="1.0.*-*" />
+    <PackageReference Include="Picea" Version="1.0.34-rc-0002" />
     <PackageReference Include="Picea.Glauca" Version="0.1.*-*" />
   </ItemGroup>
 

--- a/Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj
+++ b/Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Conduit\Picea.Abies.Conduit.csproj" />
-    <PackageReference Include="Picea" Version="1.0.*-*" />
+    <PackageReference Include="Picea" Version="1.0.34-rc-0002" />
   </ItemGroup>
 
 </Project>

--- a/Picea.Abies.Conduit/Picea.Abies.Conduit.csproj
+++ b/Picea.Abies.Conduit/Picea.Abies.Conduit.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Picea" Version="1.0.*-*" />
+    <PackageReference Include="Picea" Version="1.0.34-rc-0002" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What\nPin Conduit projects to Picea 1.0.34-rc-0002 (pre-rc3).\n\n## Why\nCurrent Conduit code does not yet implement the staged decider API required by rc3.\n\n## Validation\n- dotnet build Picea.Abies.Conduit/Picea.Abies.Conduit.csproj -c Debug\n- dotnet test --project Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj -c Debug -v minimal\n\nBoth pass locally (128 tests).