### PR TITLE
feat(testing): Add test harness and deterministic replay v1

### DIFF
--- a/Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj
+++ b/Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Praefixum</InterceptorsNamespaces>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="1.19.57" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies.Testing\Picea.Abies.Testing.csproj" />
+    <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Picea.Abies.Testing.Tests/TestHarnessTests.cs
+++ b/Picea.Abies.Testing.Tests/TestHarnessTests.cs
@@ -1,8 +1,7 @@
-using Picea.Abies.Testing;
-using Picea.Abies.DOM;
-using Picea.Abies.Subscriptions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Picea.Abies.DOM;
+using Picea.Abies.Subscriptions;
 
 namespace Picea.Abies.Testing.Tests;
 
@@ -86,7 +85,7 @@ public sealed class TestHarnessTests
     {
         var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
 
-        var act = () => harness.MockCommand<AddFromCommand>((Func<AddFromCommand, Message>)null!);
+        var act = () => harness.MockCommand((Func<AddFromCommand, Message>)null!);
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -306,7 +305,7 @@ public sealed class TestHarnessTests
         public static bool IsTerminal(TestModel state) => false;
 
         public static Document View(TestModel model) =>
-            new("Test", Picea.Abies.Html.Elements.div([], []));
+            new("Test", Html.Elements.div([], []));
 
         public static Subscription Subscriptions(TestModel model) =>
             new Subscription.None();

--- a/Picea.Abies.Testing.Tests/TestHarnessTests.cs
+++ b/Picea.Abies.Testing.Tests/TestHarnessTests.cs
@@ -1,0 +1,314 @@
+using Picea.Abies.Testing;
+using Picea.Abies.DOM;
+using Picea.Abies.Subscriptions;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Picea.Abies.Testing.Tests;
+
+public sealed class TestHarnessTests
+{
+    [Test]
+    public async Task Dispatch_AppliesDecidedEventsAndTransitionsModel()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        harness.Dispatch(new Add(3));
+
+        await Assert.That(harness.Model.Value).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task DispatchMany_AppliesMessagesInOrder()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        harness.DispatchMany([
+            new Add(2),
+            new Add(5),
+            new Add(-1)
+        ]);
+
+        await Assert.That(harness.Model.Value).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task DrainCommands_UsesTypedMocksAndClearsQueue()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+        harness.MockCommand<AddFromCommand>(command => new Add(command.Delta));
+
+        harness.Dispatch(new QueueAdd(4));
+        await Assert.That(harness.PendingCommandCount).IsEqualTo(1);
+
+        harness.DrainCommands();
+
+        await Assert.That(harness.Model.Value).IsEqualTo(4);
+        await Assert.That(harness.PendingCommandCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DrainCommands_ThrowsWhenMockMissing()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        harness.Dispatch(new QueueAdd(1));
+
+        var act = () => harness.DrainCommands();
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task DrainCommands_UsesDeterministicIterationGuard()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(
+            Unit.Value,
+            new TestHarnessOptions(MaxTransitions: 100, MaxDrainIterations: 3));
+
+        harness.MockCommand<LoopCommand>(_ => new QueueLoop());
+        harness.Dispatch(new StartLoop());
+
+        var act = () => harness.DrainCommands();
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task DispatchMany_ThrowsWhenMessagesIsNull()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        var act = () => harness.DispatchMany(null!);
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task MockCommand_SingleMessageOverload_ThrowsWhenNull()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        var act = () => harness.MockCommand<AddFromCommand>((Func<AddFromCommand, Message>)null!);
+        await Assert.That(act).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Dispatch_UsesTransitionGuardForNonTerminatingFlow()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(
+            Unit.Value,
+            new TestHarnessOptions(MaxTransitions: 2, MaxDrainIterations: 100));
+
+        harness.MockCommand<LoopCommand>(_ => [new QueueLoop()]);
+        harness.Dispatch(new StartLoop());
+
+        var act = () => harness.DrainCommands();
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Create_ThrowsWhenOptionsInvalid()
+    {
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.Create(
+            Unit.Value,
+            new TestHarnessOptions(MaxTransitions: 0, MaxDrainIterations: 1));
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task LoadAndReplaySession_AppliesMessagesInOrder()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+        var sessionJson = BuildReplaySessionJson(2, 5, -1);
+
+        harness.LoadAndReplaySession(sessionJson, MapReplayEntryToMessage);
+
+        await Assert.That(harness.Model.Value).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsUnknownSchemaVersion()
+    {
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        replayDocument["schemaVersion"] = "v2";
+
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(replayDocument.ToJsonString());
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsMalformedPayloadEntries()
+    {
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        var firstEntry = replayDocument["entries"]!.AsArray()[0]!.AsObject();
+        firstEntry["payload"] = "invalid";
+
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(replayDocument.ToJsonString());
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsMalformedJson()
+    {
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession("{");
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsNullMetadata()
+    {
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        replayDocument["metadata"] = null;
+
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(replayDocument.ToJsonString());
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsNullEntry()
+    {
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        replayDocument["entries"]!.AsArray()[0] = null;
+
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(replayDocument.ToJsonString());
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task LoadReplaySession_RejectsSequenceMismatch()
+    {
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        var firstEntry = replayDocument["entries"]!.AsArray()[0]!.AsObject();
+        firstEntry["sequence"] = 2;
+
+        var act = () => TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(replayDocument.ToJsonString());
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ReplaySession_IsDeterministicForSameSession()
+    {
+        var sessionJson = BuildReplaySessionJson(4, -1, 3, 6);
+        var session = TestHarness<TestProgram, TestModel, Unit>.LoadReplaySession(sessionJson);
+
+        var firstRun = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+        var secondRun = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+
+        firstRun.ReplaySession(session, MapReplayEntryToMessage);
+        secondRun.ReplaySession(session, MapReplayEntryToMessage);
+
+        await Assert.That(firstRun.Model.Value).IsEqualTo(secondRun.Model.Value);
+        await Assert.That(firstRun.Model.Value).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task LoadAndReplaySession_RejectsInvalidEntryPayload()
+    {
+        var harness = TestHarness<TestProgram, TestModel, Unit>.Create(Unit.Value);
+        var replayDocument = JsonNode.Parse(BuildReplaySessionJson(1))!.AsObject();
+        var firstEntry = replayDocument["entries"]!.AsArray()[0]!.AsObject();
+        firstEntry["payload"] = new JsonObject();
+
+        var act = () => harness.LoadAndReplaySession(replayDocument.ToJsonString(), MapReplayEntryToMessage);
+
+        await Assert.That(act).Throws<InvalidOperationException>();
+    }
+
+    private static string BuildReplaySessionJson(params int[] deltas)
+    {
+        var entries = deltas
+            .Select((delta, index) => new TestHarnessReplayEntryV1
+            {
+                Sequence = index,
+                MessageType = nameof(Add),
+                Payload = JsonSerializer.SerializeToElement(new AddReplayPayload(delta))
+            })
+            .ToArray();
+
+        var session = new TestHarnessReplaySessionV1
+        {
+            SchemaVersion = TestHarnessReplaySchema.Version1,
+            Metadata = new TestHarnessReplayMetadataV1
+            {
+                SessionId = "session-165",
+                ProgramName = nameof(TestProgram),
+                ProgramVersion = "1.0.0",
+                RecordedAtUnixMs = 1
+            },
+            Entries = entries
+        };
+
+        return JsonSerializer.Serialize(session);
+    }
+
+    private static Message MapReplayEntryToMessage(TestHarnessReplayEntryV1 entry) =>
+        entry.MessageType switch
+        {
+            nameof(Add) => ParseAddReplayMessage(entry.Payload),
+            _ => throw new InvalidOperationException($"Unsupported replay message type: {entry.MessageType}")
+        };
+
+    private static Message ParseAddReplayMessage(JsonElement payload)
+    {
+        if (payload.TryGetProperty("delta", out var deltaProperty) is false &&
+            payload.TryGetProperty("Delta", out deltaProperty) is false)
+        {
+            throw new InvalidOperationException("Replay payload is invalid: delta is required.");
+        }
+
+        return new Add(deltaProperty.GetInt32());
+    }
+
+    private sealed record AddReplayPayload(int Delta);
+
+    public sealed record TestModel(int Value);
+
+    public interface TestMessage : Message;
+    public sealed record Add(int Delta) : TestMessage;
+    public sealed record QueueAdd(int Delta) : TestMessage;
+    public sealed record StartLoop : TestMessage;
+    public sealed record QueueLoop : TestMessage;
+    public sealed record CommandRejected(string Reason) : TestMessage;
+
+    public sealed record AddFromCommand(int Delta) : Command;
+    public sealed record LoopCommand : Command;
+
+    public sealed class TestProgram : Program<TestModel, Unit>
+    {
+        public static (TestModel, Command) Initialize(Unit argument) =>
+            (new TestModel(0), Commands.None);
+
+        public static (TestModel, Command) Transition(TestModel model, Message message) =>
+            message switch
+            {
+                Add add => (model with { Value = model.Value + add.Delta }, Commands.None),
+                QueueAdd queue => (model, new AddFromCommand(queue.Delta)),
+                QueueLoop => (model, new LoopCommand()),
+                CommandRejected => (model, Commands.None),
+                _ => (model, Commands.None)
+            };
+
+        public static Result<Message[], Message> Decide(TestModel state, Message command) =>
+            command switch
+            {
+                Add add => Result<Message[], Message>.Ok([add]),
+                QueueAdd queue => Result<Message[], Message>.Ok([queue]),
+                StartLoop => Result<Message[], Message>.Ok([new QueueLoop()]),
+                QueueLoop loop => Result<Message[], Message>.Ok([loop]),
+                _ => Result<Message[], Message>.Err(new CommandRejected($"Unsupported command: {command.GetType().Name}"))
+            };
+
+        public static bool IsTerminal(TestModel state) => false;
+
+        public static Document View(TestModel model) =>
+            new("Test", Picea.Abies.Html.Elements.div([], []));
+
+        public static Subscription Subscriptions(TestModel model) =>
+            new Subscription.None();
+    }
+}

--- a/Picea.Abies.Testing/Picea.Abies.Testing.csproj
+++ b/Picea.Abies.Testing/Picea.Abies.Testing.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Picea.Abies.Testing</PackageId>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Picea.Abies.Testing/TestHarness.cs
+++ b/Picea.Abies.Testing/TestHarness.cs
@@ -1,0 +1,278 @@
+using System.Text.Json;
+
+namespace Picea.Abies.Testing;
+
+/// <summary>
+/// In-memory harness for testing Program workflows deterministically without a browser runtime.
+/// </summary>
+public sealed class TestHarness<TProgram, TModel, TArgument>
+    where TProgram : Program<TModel, TArgument>
+{
+    private const int MaxBatchDepth = 4_096;
+    private readonly Queue<Command> _pendingCommands = new();
+    private readonly Dictionary<Type, Func<Command, IReadOnlyList<Message>>> _commandMocks = new();
+    private readonly TestHarnessOptions _options;
+    private int _transitionCount;
+
+    private TestHarness(TModel initialModel, TestHarnessOptions options)
+    {
+        Model = initialModel;
+        _options = options;
+    }
+
+    /// <summary>
+    /// Current model after all dispatched messages and drained commands.
+    /// </summary>
+    public TModel Model { get; private set; }
+
+    /// <summary>
+    /// Commands that have been produced but not yet drained.
+    /// </summary>
+    public IReadOnlyList<Command> PendingCommands => _pendingCommands.ToArray();
+
+    /// <summary>
+    /// Number of queued commands waiting to be drained.
+    /// </summary>
+    public int PendingCommandCount => _pendingCommands.Count;
+
+    /// <summary>
+    /// Creates a harness from the program's initial state and initial command.
+    /// </summary>
+    public static TestHarness<TProgram, TModel, TArgument> Create(
+        TArgument argument,
+        TestHarnessOptions? options = null)
+    {
+        var resolvedOptions = options ?? new TestHarnessOptions();
+        resolvedOptions.Validate();
+
+        var (model, initialCommand) = TProgram.Initialize(argument);
+        var harness = new TestHarness<TProgram, TModel, TArgument>(model, resolvedOptions);
+        harness.EnqueueCommand(initialCommand);
+
+        return harness;
+    }
+
+    /// <summary>
+    /// Loads and validates a replay session payload using the deterministic v1 schema.
+    /// </summary>
+    /// <param name="sessionJson">The session JSON payload.</param>
+    /// <returns>The validated replay session.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sessionJson"/> is empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the payload is invalid or unsupported.</exception>
+    public static TestHarnessReplaySessionV1 LoadReplaySession(string sessionJson)
+    {
+        if (string.IsNullOrWhiteSpace(sessionJson))
+        {
+            throw new ArgumentException("Session payload cannot be empty.", nameof(sessionJson));
+        }
+
+        TestHarnessReplaySessionV1? session;
+        try
+        {
+            session = JsonSerializer.Deserialize(sessionJson, TestHarnessReplayJsonContext.Default.TestHarnessReplaySessionV1);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException("Session payload is invalid JSON.", exception);
+        }
+
+        if (session is null)
+        {
+            throw new InvalidOperationException("Session payload is invalid: the root document is missing.");
+        }
+
+        session.Validate();
+        return session;
+    }
+
+    /// <summary>
+    /// Replays a validated session by mapping each entry to a domain message and dispatching it in sequence order.
+    /// </summary>
+    /// <param name="session">The replay session to execute.</param>
+    /// <param name="mapEntryToMessage">Maps one replay entry into the program-specific message.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when entry mapping fails.</exception>
+    public void ReplaySession(
+        TestHarnessReplaySessionV1 session,
+        Func<TestHarnessReplayEntryV1, Message> mapEntryToMessage)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(mapEntryToMessage);
+
+        session.Validate();
+
+        for (var index = 0; index < session.Entries.Count; index++)
+        {
+            var entry = session.Entries[index];
+            Message message;
+
+            try
+            {
+                message = mapEntryToMessage(entry);
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidOperationException(
+                    $"Session entry at index {index} ({entry.MessageType}) could not be mapped to a message.",
+                    exception);
+            }
+
+            Dispatch(message);
+        }
+    }
+
+    /// <summary>
+    /// Loads and replays a session payload in one operation.
+    /// </summary>
+    /// <param name="sessionJson">The session JSON payload.</param>
+    /// <param name="mapEntryToMessage">Maps one replay entry into the program-specific message.</param>
+    public void LoadAndReplaySession(
+        string sessionJson,
+        Func<TestHarnessReplayEntryV1, Message> mapEntryToMessage)
+    {
+        var session = LoadReplaySession(sessionJson);
+        ReplaySession(session, mapEntryToMessage);
+    }
+
+    /// <summary>
+    /// Registers a typed command mock that returns one or more messages for the command.
+    /// </summary>
+    public void MockCommand<TCommand>(Func<TCommand, IReadOnlyList<Message>> mock)
+        where TCommand : Command
+    {
+        ArgumentNullException.ThrowIfNull(mock);
+
+        _commandMocks[typeof(TCommand)] = command =>
+        {
+            var typedCommand = (TCommand)command;
+            return mock(typedCommand).ToArray();
+        };
+    }
+
+    /// <summary>
+    /// Registers a typed command mock that returns one message for the command.
+    /// </summary>
+    public void MockCommand<TCommand>(Func<TCommand, Message> mock)
+        where TCommand : Command
+    {
+        ArgumentNullException.ThrowIfNull(mock);
+        MockCommand<TCommand>(command => [mock(command)]);
+    }
+
+    /// <summary>
+    /// Dispatches one message through Decide and Transition.
+    /// </summary>
+    public void Dispatch(Message message) =>
+        DispatchMany([message]);
+
+    /// <summary>
+    /// Dispatches messages in order through Decide and Transition.
+    /// </summary>
+    public void DispatchMany(IEnumerable<Message> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        foreach (var message in messages)
+        {
+            DispatchCore(message);
+        }
+    }
+
+    /// <summary>
+    /// Drains the command queue by invoking registered mocks and dispatching emitted messages.
+    /// </summary>
+    public void DrainCommands()
+    {
+        var iterations = 0;
+
+        while (_pendingCommands.Count > 0)
+        {
+            iterations++;
+            if (iterations > _options.MaxDrainIterations)
+            {
+                throw new InvalidOperationException(
+                    $"DrainCommands exceeded {_options.MaxDrainIterations} iterations. " +
+                    "The command graph is likely non-terminating.");
+            }
+
+            var command = _pendingCommands.Dequeue();
+            if (_commandMocks.TryGetValue(command.GetType(), out var mock) is false)
+            {
+                throw new InvalidOperationException(
+                    $"No command mock registered for {command.GetType().Name}. " +
+                    "Register it via MockCommand<TCommand>(...).");
+            }
+
+            var resultingMessages = mock(command);
+            DispatchMany(resultingMessages);
+        }
+    }
+
+    private void DispatchCore(Message message)
+    {
+        if (TProgram.IsTerminal(Model))
+        {
+            return;
+        }
+
+        var decision = TProgram.Decide(Model, message);
+        if (decision.IsErr)
+        {
+            ApplyTransition(decision.Error);
+            return;
+        }
+
+        foreach (var decidedEvent in decision.Value)
+        {
+            ApplyTransition(decidedEvent);
+        }
+    }
+
+    private void ApplyTransition(Message message)
+    {
+        _transitionCount++;
+        if (_transitionCount > _options.MaxTransitions)
+        {
+            throw new InvalidOperationException(
+                $"Dispatch exceeded {_options.MaxTransitions} transitions. " +
+                "The message flow is likely non-terminating.");
+        }
+
+        var (nextModel, command) = TProgram.Transition(Model, message);
+        Model = nextModel;
+        EnqueueCommand(command);
+    }
+
+    private void EnqueueCommand(Command command)
+    {
+        var stack = new Stack<(Command Command, int Depth)>();
+        stack.Push((command, 0));
+
+        while (stack.Count > 0)
+        {
+            var (current, depth) = stack.Pop();
+            if (current is Command.None)
+            {
+                continue;
+            }
+
+            if (current is Command.Batch batch)
+            {
+                if (depth >= MaxBatchDepth)
+                {
+                    throw new InvalidOperationException(
+                        $"Command batch nesting exceeded {MaxBatchDepth}. The command graph is likely malformed.");
+                }
+
+                for (var i = batch.Commands.Count - 1; i >= 0; i--)
+                {
+                    stack.Push((batch.Commands[i], depth + 1));
+                }
+
+                continue;
+            }
+
+            _pendingCommands.Enqueue(current);
+        }
+    }
+}

--- a/Picea.Abies.Testing/TestHarness.cs
+++ b/Picea.Abies.Testing/TestHarness.cs
@@ -11,6 +11,7 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
     private const int MaxBatchDepth = 4_096;
     private readonly Queue<Command> _pendingCommands = new();
     private readonly Dictionary<Type, Func<Command, IReadOnlyList<Message>>> _commandMocks = new();
+    private readonly List<Type> _mockRegistrationOrder = [];
     private readonly TestHarnessOptions _options;
     private int _transitionCount;
 
@@ -104,18 +105,8 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
         for (var index = 0; index < session.Entries.Count; index++)
         {
             var entry = session.Entries[index];
-            Message message;
-
-            try
-            {
-                message = mapEntryToMessage(entry);
-            }
-            catch (Exception exception)
-            {
-                throw new InvalidOperationException(
-                    $"Session entry at index {index} ({entry.MessageType}) could not be mapped to a message.",
-                    exception);
-            }
+            var message = mapEntryToMessage(entry) ?? throw new InvalidOperationException(
+                $"Session entry at index {index} ({entry.MessageType}) was mapped to null.");
 
             Dispatch(message);
         }
@@ -142,10 +133,30 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
     {
         ArgumentNullException.ThrowIfNull(mock);
 
+        if (_mockRegistrationOrder.Contains(typeof(TCommand)) is false)
+        {
+            _mockRegistrationOrder.Add(typeof(TCommand));
+        }
+
         _commandMocks[typeof(TCommand)] = command =>
         {
             var typedCommand = (TCommand)command;
-            return mock(typedCommand).ToArray();
+            var messages = mock(typedCommand);
+
+            if (messages is null)
+            {
+                throw new InvalidOperationException(
+                    $"Mock for command '{typeof(TCommand).Name}' returned null. Command mocks must return a non-null message list.");
+            }
+
+            var materialized = messages.ToArray();
+            if (materialized.Any(static message => message is null))
+            {
+                throw new InvalidOperationException(
+                    $"Mock for command '{typeof(TCommand).Name}' returned a message list containing null entries.");
+            }
+
+            return materialized;
         };
     }
 
@@ -196,7 +207,8 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
             }
 
             var command = _pendingCommands.Dequeue();
-            if (_commandMocks.TryGetValue(command.GetType(), out var mock) is false)
+            var mock = ResolveCommandMock(command.GetType());
+            if (mock is null)
             {
                 throw new InvalidOperationException(
                     $"No command mock registered for {command.GetType().Name}. " +
@@ -274,5 +286,23 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
 
             _pendingCommands.Enqueue(current);
         }
+    }
+
+    private Func<Command, IReadOnlyList<Message>>? ResolveCommandMock(Type commandType)
+    {
+        if (_commandMocks.TryGetValue(commandType, out var exact))
+        {
+            return exact;
+        }
+
+        foreach (var registeredType in _mockRegistrationOrder)
+        {
+            if (registeredType.IsAssignableFrom(commandType) && _commandMocks.TryGetValue(registeredType, out var assignable))
+            {
+                return assignable;
+            }
+        }
+
+        return null;
     }
 }

--- a/Picea.Abies.Testing/TestHarnessOptions.cs
+++ b/Picea.Abies.Testing/TestHarnessOptions.cs
@@ -1,0 +1,24 @@
+namespace Picea.Abies.Testing;
+
+/// <summary>
+/// Guardrails used by <see cref="TestHarness{TProgram,TModel,TArgument}"/> to keep tests deterministic.
+/// </summary>
+/// <param name="MaxTransitions">Maximum number of state transitions allowed before failing.</param>
+/// <param name="MaxDrainIterations">Maximum number of command-drain iterations before failing.</param>
+public sealed record TestHarnessOptions(
+    int MaxTransitions = 10_000,
+    int MaxDrainIterations = 10_000)
+{
+    internal void Validate()
+    {
+        if (MaxTransitions <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxTransitions), "MaxTransitions must be greater than zero.");
+        }
+
+        if (MaxDrainIterations <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxDrainIterations), "MaxDrainIterations must be greater than zero.");
+        }
+    }
+}

--- a/Picea.Abies.Testing/TestHarnessReplayJsonContext.cs
+++ b/Picea.Abies.Testing/TestHarnessReplayJsonContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Picea.Abies.Testing;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(TestHarnessReplaySessionV1))]
+[JsonSerializable(typeof(TestHarnessReplayMetadataV1))]
+[JsonSerializable(typeof(TestHarnessReplayEntryV1))]
+internal sealed partial class TestHarnessReplayJsonContext : JsonSerializerContext;

--- a/Picea.Abies.Testing/TestHarnessReplaySessionV1.cs
+++ b/Picea.Abies.Testing/TestHarnessReplaySessionV1.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Picea.Abies.Testing;
+
+/// <summary>
+/// Deterministic replay schema contract used by <see cref="TestHarness{TProgram, TModel, TArgument}"/>.
+/// </summary>
+public static class TestHarnessReplaySchema
+{
+    /// <summary>
+    /// Current replay session schema version.
+    /// </summary>
+    public const string Version1 = "v1";
+}
+
+/// <summary>
+/// Deterministic replay session payload (v1).
+/// </summary>
+public sealed record TestHarnessReplaySessionV1
+{
+    /// <summary>
+    /// Schema version for compatibility checks.
+    /// </summary>
+    [JsonPropertyName("schemaVersion")]
+    public required string SchemaVersion { get; init; }
+
+    /// <summary>
+    /// Explicit metadata for traceability and deterministic replay diagnostics.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public required TestHarnessReplayMetadataV1 Metadata { get; init; }
+
+    /// <summary>
+    /// Ordered message entries to replay.
+    /// </summary>
+    [JsonPropertyName("entries")]
+    public required IReadOnlyList<TestHarnessReplayEntryV1> Entries { get; init; }
+
+    internal void Validate()
+    {
+        if (SchemaVersion != TestHarnessReplaySchema.Version1)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported session schema version '{SchemaVersion}'. Expected '{TestHarnessReplaySchema.Version1}'.");
+        }
+
+        if (Metadata is null)
+        {
+            throw new InvalidOperationException("Session payload is invalid: metadata is required.");
+        }
+
+        Metadata.Validate();
+
+        if (Entries is null)
+        {
+            throw new InvalidOperationException("Session payload is invalid: entries is required.");
+        }
+
+        for (var index = 0; index < Entries.Count; index++)
+        {
+            var entry = Entries[index];
+            if (entry is null)
+            {
+                throw new InvalidOperationException($"Session payload is invalid: entry {index} is required.");
+            }
+
+            entry.Validate(index);
+        }
+    }
+}
+
+/// <summary>
+/// Replay session metadata.
+/// </summary>
+public sealed record TestHarnessReplayMetadataV1
+{
+    /// <summary>
+    /// Stable session identifier.
+    /// </summary>
+    [JsonPropertyName("sessionId")]
+    public required string SessionId { get; init; }
+
+    /// <summary>
+    /// Program identity that produced the replay payload.
+    /// </summary>
+    [JsonPropertyName("programName")]
+    public required string ProgramName { get; init; }
+
+    /// <summary>
+    /// Program version emitted by the recorder.
+    /// </summary>
+    [JsonPropertyName("programVersion")]
+    public required string ProgramVersion { get; init; }
+
+    /// <summary>
+    /// UTC unix milliseconds when the session was recorded.
+    /// </summary>
+    [JsonPropertyName("recordedAtUnixMs")]
+    public required long RecordedAtUnixMs { get; init; }
+
+    internal void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(SessionId))
+        {
+            throw new InvalidOperationException("Session payload is invalid: metadata.sessionId is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(ProgramName))
+        {
+            throw new InvalidOperationException("Session payload is invalid: metadata.programName is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(ProgramVersion))
+        {
+            throw new InvalidOperationException("Session payload is invalid: metadata.programVersion is required.");
+        }
+
+        if (RecordedAtUnixMs < 0)
+        {
+            throw new InvalidOperationException("Session payload is invalid: metadata.recordedAtUnixMs must be zero or greater.");
+        }
+    }
+}
+
+/// <summary>
+/// One replay entry in the deterministic v1 schema.
+/// </summary>
+public sealed record TestHarnessReplayEntryV1
+{
+    /// <summary>
+    /// Deterministic sequence number. Must match the entry index.
+    /// </summary>
+    [JsonPropertyName("sequence")]
+    public required int Sequence { get; init; }
+
+    /// <summary>
+    /// Message identity used by entry-to-message mapping.
+    /// </summary>
+    [JsonPropertyName("messageType")]
+    public required string MessageType { get; init; }
+
+    /// <summary>
+    /// Message payload object consumed by entry-to-message mapping.
+    /// </summary>
+    [JsonPropertyName("payload")]
+    public required JsonElement Payload { get; init; }
+
+    internal void Validate(int index)
+    {
+        if (Sequence != index)
+        {
+            throw new InvalidOperationException(
+                $"Session payload is invalid: entry {index} sequence must be {index}, but was {Sequence}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(MessageType))
+        {
+            throw new InvalidOperationException($"Session payload is invalid: entry {index} messageType is required.");
+        }
+
+        if (Payload.ValueKind is not JsonValueKind.Object)
+        {
+            throw new InvalidOperationException(
+                $"Session payload is invalid: entry {index} payload must be a JSON object.");
+        }
+    }
+}

--- a/Picea.Abies.sln
+++ b/Picea.Abies.sln
@@ -85,6 +85,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.UI.Demo.Testing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.UI.Demo", "Picea.Abies.UI.Demo\Picea.Abies.UI.Demo.csproj", "{F96DC59E-57D2-40B5-B188-C45953B6D2E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Testing", "Picea.Abies.Testing\Picea.Abies.Testing.csproj", "{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Testing.Tests", "Picea.Abies.Testing.Tests\Picea.Abies.Testing.Tests.csproj", "{052F811A-ECDC-4223-A488-2E0BBD0D2163}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -587,6 +591,30 @@ Global
 		{F96DC59E-57D2-40B5-B188-C45953B6D2E6}.Release|x64.Build.0 = Release|Any CPU
 		{F96DC59E-57D2-40B5-B188-C45953B6D2E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F96DC59E-57D2-40B5-B188-C45953B6D2E6}.Release|x86.Build.0 = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|x64.Build.0 = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|x64.ActiveCfg = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|x64.Build.0 = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{F5AF5676-2DD7-4326-AE78-3E64CA7B9CD3}.Release|x86.Build.0 = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|x64.Build.0 = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Debug|x86.Build.0 = Debug|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|Any CPU.Build.0 = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x64.ActiveCfg = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x64.Build.0 = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x86.ActiveCfg = Release|Any CPU
+		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## 📝 Description

### What
Adds `Picea.Abies.Testing` and `Picea.Abies.Testing.Tests` with a deterministic test harness for MVU programs.

### Why
Implements issue #165 phases 1-2 to enable fast, browserless regression testing of state-machine behavior and deterministic replay.

### How
- Introduces `TestHarness<TProgram, TModel, TArgument>` with:
  - `Create`, `Dispatch`, `DispatchMany`, `DrainCommands`
  - typed `MockCommand<TCommand>(...)`
  - deterministic guards for transition and drain iteration limits
- Adds deterministic replay schema v1 (`schemaVersion`, metadata, ordered entries)
- Adds replay APIs:
  - `LoadReplaySession`
  - `ReplaySession`
  - `LoadAndReplaySession`
- Adds source-generated JSON context for trim-safe replay deserialization
- Adds comprehensive tests for happy-path and failure-path validation (malformed JSON, unknown schema version, null metadata/entries, sequence mismatch, deterministic replay)

## 🔗 Related Issues
Fixes #165

## ✅ Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test update

## 🧪 Testing
### Test Coverage
- [x] Unit tests added/updated

### Testing Details
- `dotnet test --project Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj -v minimal`

## ✨ Changes Made
- Added new package project: `Picea.Abies.Testing`
- Added new test project: `Picea.Abies.Testing.Tests`
- Implemented TestHarness core dispatch/drain/mock APIs
- Implemented deterministic replay session contract (v1)
- Implemented replay load/replay APIs with fail-fast validation
- Added replay and guard behavior tests

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Tests added/updated and passing
