### PR TITLE
feat(testing): Add harness replay diagnostics and export APIs

### DIFF
--- a/Picea.Abies.Benchmarks/Picea.Abies.Benchmarks.csproj
+++ b/Picea.Abies.Benchmarks/Picea.Abies.Benchmarks.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Browser\Picea.Abies.Browser.csproj" />
+    <ProjectReference Include="..\Picea.Abies.Testing\Picea.Abies.Testing.csproj" />
     <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
   </ItemGroup>
 

--- a/Picea.Abies.Benchmarks/TestHarnessReplayBenchmarks.cs
+++ b/Picea.Abies.Benchmarks/TestHarnessReplayBenchmarks.cs
@@ -1,0 +1,112 @@
+using BenchmarkDotNet.Attributes;
+using Picea.Abies.DOM;
+using Picea.Abies.Subscriptions;
+using Picea.Abies.Testing;
+using System.Text.Json;
+
+namespace Picea.Abies.Benchmarks;
+
+/// <summary>
+/// Baseline replay throughput benchmark for the testing harness using a deterministic 10k-entry session.
+/// </summary>
+[MemoryDiagnoser]
+[MarkdownExporter]
+[JsonExporterAttribute.Full]
+[JsonExporterAttribute.FullCompressed]
+public class TestHarnessReplayBenchmarks
+{
+    private const int ReplayEntryCount = 10_000;
+    private string _sessionJson = null!;
+
+    [GlobalSetup]
+    public void Setup() =>
+        _sessionJson = BuildReplaySessionJson(ReplayEntryCount);
+
+    [Benchmark(Description = "TestHarness load+replay 10k messages")]
+    public int LoadAndReplay10k()
+    {
+        var harness = TestHarness<ReplayBenchmarkProgram, ReplayBenchmarkModel, Unit>.Create(Unit.Value);
+        harness.LoadAndReplaySession(_sessionJson, MapReplayEntryToMessage);
+        return harness.Model.Value;
+    }
+
+    private static string BuildReplaySessionJson(int entryCount)
+    {
+        var entries = Enumerable
+            .Range(0, entryCount)
+            .Select(index => new TestHarnessReplayEntryV1
+            {
+                Sequence = index,
+                MessageType = nameof(Add),
+                Payload = JsonSerializer.SerializeToElement(new AddPayload(1))
+            })
+            .ToArray();
+
+        var session = new TestHarnessReplaySessionV1
+        {
+            SchemaVersion = TestHarnessReplaySchema.Version1,
+            Metadata = new TestHarnessReplayMetadataV1
+            {
+                SessionId = "benchmark-10k",
+                ProgramName = nameof(ReplayBenchmarkProgram),
+                ProgramVersion = "1.0.0",
+                RecordedAtUnixMs = 1
+            },
+            Entries = entries
+        };
+
+        return TestHarness<ReplayBenchmarkProgram, ReplayBenchmarkModel, Unit>.SerializeReplaySession(session);
+    }
+
+    private static Message MapReplayEntryToMessage(TestHarnessReplayEntryV1 entry)
+    {
+        if (entry.MessageType != nameof(Add))
+        {
+            throw new InvalidOperationException($"Unsupported replay message type: {entry.MessageType}");
+        }
+
+        if (entry.Payload.TryGetProperty("Delta", out var deltaProperty) is false &&
+            entry.Payload.TryGetProperty("delta", out deltaProperty) is false)
+        {
+            throw new InvalidOperationException("Replay payload is invalid: delta is required.");
+        }
+
+        return new Add(deltaProperty.GetInt32());
+    }
+
+    private sealed record AddPayload(int Delta);
+
+    private sealed record ReplayBenchmarkModel(int Value);
+
+    private interface BenchmarkMessage : Message;
+
+    private sealed record Add(int Delta) : BenchmarkMessage;
+
+    private sealed class ReplayBenchmarkProgram : Program<ReplayBenchmarkModel, Unit>
+    {
+        public static (ReplayBenchmarkModel, Command) Initialize(Unit argument) =>
+            (new ReplayBenchmarkModel(0), Commands.None);
+
+        public static (ReplayBenchmarkModel, Command) Transition(ReplayBenchmarkModel model, Message message) =>
+            message switch
+            {
+                Add add => (model with { Value = model.Value + add.Delta }, Commands.None),
+                _ => (model, Commands.None)
+            };
+
+        public static Result<Message[], Message> Decide(ReplayBenchmarkModel state, Message command) =>
+            command switch
+            {
+                Add add => Result<Message[], Message>.Ok([add]),
+                _ => Result<Message[], Message>.Err(command)
+            };
+
+        public static bool IsTerminal(ReplayBenchmarkModel state) => false;
+
+        public static Document View(ReplayBenchmarkModel model) =>
+            new("Bench", Html.Elements.div([], []));
+
+        public static Subscription Subscriptions(ReplayBenchmarkModel model) =>
+            new Subscription.None();
+    }
+}

--- a/Picea.Abies.Testing.Tests/TestHarnessReplayDiagnosticsTests.cs
+++ b/Picea.Abies.Testing.Tests/TestHarnessReplayDiagnosticsTests.cs
@@ -1,0 +1,196 @@
+using Picea.Abies.DOM;
+using Picea.Abies.Subscriptions;
+using System.Text.Json;
+
+namespace Picea.Abies.Testing.Tests;
+
+public sealed class TestHarnessReplayDiagnosticsTests
+{
+    [Test]
+    public async Task ExportReplaySession_CapturesDispatchAndReplayMessages()
+    {
+        var harness = TestHarness<ReplayProgram, ReplayModel, Unit>.Create(Unit.Value);
+        harness.Dispatch(new Add(2));
+        harness.Dispatch(new Add(3));
+        harness.LoadAndReplaySession(BuildReplaySessionJson(5), MapReplayEntryToMessage);
+
+        var exported = harness.ExportReplaySession(
+            MapHistoryEntryToReplayPayload,
+            metadata: CreateMetadata("export-session-1"));
+
+        await Assert.That(exported.SchemaVersion).IsEqualTo(TestHarnessReplaySchema.Version1);
+        await Assert.That(exported.Entries.Count).IsEqualTo(3);
+        await Assert.That(ParseAddPayload(exported.Entries[0].Payload)).IsEqualTo(new Add(2));
+        await Assert.That(ParseAddPayload(exported.Entries[1].Payload)).IsEqualTo(new Add(3));
+        await Assert.That(ParseAddPayload(exported.Entries[2].Payload)).IsEqualTo(new Add(5));
+        await Assert.That(harness.MessageHistory[0].Source).IsEqualTo(TestHarnessMessageSource.Dispatch);
+        await Assert.That(harness.MessageHistory[1].Source).IsEqualTo(TestHarnessMessageSource.Dispatch);
+        await Assert.That(harness.MessageHistory[2].Source).IsEqualTo(TestHarnessMessageSource.Replay);
+    }
+
+    [Test]
+    public async Task ExportReplaySessionJson_ProducesLoadableSession()
+    {
+        var harness = TestHarness<ReplayProgram, ReplayModel, Unit>.Create(Unit.Value);
+        harness.Dispatch(new Add(7));
+
+        var sessionJson = harness.ExportReplaySessionJson(
+            MapHistoryEntryToReplayPayload,
+            metadata: CreateMetadata("export-json-session"));
+
+        var loaded = TestHarness<ReplayProgram, ReplayModel, Unit>.LoadReplaySession(sessionJson);
+
+        await Assert.That(loaded.Metadata.SessionId).IsEqualTo("export-json-session");
+        await Assert.That(loaded.Entries.Count).IsEqualTo(1);
+        await Assert.That(ParseAddPayload(loaded.Entries[0].Payload)).IsEqualTo(new Add(7));
+    }
+
+    [Test]
+    public async Task ReplaySession_RecordsReplayMetadataHistory()
+    {
+        var harness = TestHarness<ReplayProgram, ReplayModel, Unit>.Create(Unit.Value);
+
+        harness.LoadAndReplaySession(BuildReplaySessionJson(1, 2), MapReplayEntryToMessage);
+
+        await Assert.That(harness.ReplayMetadataHistory.Count).IsEqualTo(1);
+        await Assert.That(harness.ReplayMetadataHistory[0].SessionId).IsEqualTo("replay-session");
+        await Assert.That(harness.ReplayMetadataHistory[0].ProgramName).IsEqualTo(nameof(ReplayProgram));
+    }
+
+    [Test]
+    public async Task DiagnosticsHistory_TracksMessagesDecisionsAndCommands()
+    {
+        var harness = TestHarness<ReplayProgram, ReplayModel, Unit>.Create(Unit.Value);
+        harness.MockCommand<AddFromCommand>(command => new Add(command.Delta));
+
+        harness.Dispatch(new QueueAdd(4));
+        harness.DrainCommands();
+
+        await Assert.That(harness.MessageHistory.Count).IsEqualTo(2);
+        await Assert.That(harness.MessageHistory[0].Message).IsTypeOf<QueueAdd>();
+        await Assert.That(harness.MessageHistory[1].Message).IsTypeOf<Add>();
+
+        await Assert.That(harness.DecisionHistory.Count).IsEqualTo(2);
+        await Assert.That(harness.DecisionHistory[0].TriggerMessage).IsTypeOf<QueueAdd>();
+        await Assert.That(harness.DecisionHistory[0].OutputMessage).IsTypeOf<QueueAdd>();
+        await Assert.That(harness.DecisionHistory[0].IsError).IsFalse();
+        await Assert.That(harness.DecisionHistory[1].TriggerMessage).IsTypeOf<Add>();
+        await Assert.That(harness.DecisionHistory[1].OutputMessage).IsTypeOf<Add>();
+        await Assert.That(harness.DecisionHistory[1].IsError).IsFalse();
+
+        await Assert.That(harness.CommandHistory.Count).IsEqualTo(2);
+        await Assert.That(harness.CommandHistory[0].Command).IsTypeOf<AddFromCommand>();
+        await Assert.That(harness.CommandHistory[0].Stage).IsEqualTo(TestHarnessCommandStage.Enqueued);
+        await Assert.That(harness.CommandHistory[1].Command).IsTypeOf<AddFromCommand>();
+        await Assert.That(harness.CommandHistory[1].Stage).IsEqualTo(TestHarnessCommandStage.Dequeued);
+    }
+
+    private static string BuildReplaySessionJson(params int[] deltas)
+    {
+        var entries = deltas
+            .Select((delta, index) => new TestHarnessReplayEntryV1
+            {
+                Sequence = index,
+                MessageType = nameof(Add),
+                Payload = JsonSerializer.SerializeToElement(new AddPayload(delta))
+            })
+            .ToArray();
+
+        var session = new TestHarnessReplaySessionV1
+        {
+            SchemaVersion = TestHarnessReplaySchema.Version1,
+            Metadata = new TestHarnessReplayMetadataV1
+            {
+                SessionId = "replay-session",
+                ProgramName = nameof(ReplayProgram),
+                ProgramVersion = "1.0.0",
+                RecordedAtUnixMs = 1
+            },
+            Entries = entries
+        };
+
+        return TestHarness<ReplayProgram, ReplayModel, Unit>.SerializeReplaySession(session);
+    }
+
+    private static Message MapReplayEntryToMessage(TestHarnessReplayEntryV1 entry)
+    {
+        if (entry.MessageType != nameof(Add))
+        {
+            throw new InvalidOperationException($"Unsupported replay message type: {entry.MessageType}");
+        }
+
+        return ParseAddPayload(entry.Payload);
+    }
+
+    private static JsonElement MapHistoryEntryToReplayPayload(TestHarnessMessageHistoryEntry entry) =>
+        entry.Message switch
+        {
+            Add add => JsonSerializer.SerializeToElement(new AddPayload(add.Delta)),
+            _ => throw new InvalidOperationException($"Unsupported message for replay export: {entry.MessageType}")
+        };
+
+    private static Add ParseAddPayload(JsonElement payload)
+    {
+        if (payload.TryGetProperty("delta", out var deltaProperty) is false &&
+            payload.TryGetProperty("Delta", out deltaProperty) is false)
+        {
+            throw new InvalidOperationException("Replay payload is invalid: delta is required.");
+        }
+
+        return new Add(deltaProperty.GetInt32());
+    }
+
+    private static TestHarnessReplayMetadataV1 CreateMetadata(string sessionId) =>
+        new()
+        {
+            SessionId = sessionId,
+            ProgramName = nameof(ReplayProgram),
+            ProgramVersion = "1.0.0",
+            RecordedAtUnixMs = 1
+        };
+
+    private sealed record ReplayModel(int Value);
+
+    private interface ReplayMessage : Message;
+
+    private sealed record Add(int Delta) : ReplayMessage;
+
+    private sealed record QueueAdd(int Delta) : ReplayMessage;
+
+    private sealed record AddPayload(int Delta);
+
+    private sealed record CommandRejected(string Reason) : ReplayMessage;
+
+    private sealed record AddFromCommand(int Delta) : Command;
+
+    private sealed class ReplayProgram : Program<ReplayModel, Unit>
+    {
+        public static (ReplayModel, Command) Initialize(Unit argument) =>
+            (new ReplayModel(0), Commands.None);
+
+        public static (ReplayModel, Command) Transition(ReplayModel model, Message message) =>
+            message switch
+            {
+                Add add => (model with { Value = model.Value + add.Delta }, Commands.None),
+                QueueAdd queue => (model, new AddFromCommand(queue.Delta)),
+                CommandRejected => (model, Commands.None),
+                _ => (model, Commands.None)
+            };
+
+        public static Result<Message[], Message> Decide(ReplayModel state, Message command) =>
+            command switch
+            {
+                Add add => Result<Message[], Message>.Ok([add]),
+                QueueAdd queue => Result<Message[], Message>.Ok([queue]),
+                _ => Result<Message[], Message>.Err(new CommandRejected($"Unsupported command: {command.GetType().Name}"))
+            };
+
+        public static bool IsTerminal(ReplayModel state) => false;
+
+        public static Document View(ReplayModel model) =>
+            new("Replay", Html.Elements.div([], []));
+
+        public static Subscription Subscriptions(ReplayModel model) =>
+            new Subscription.None();
+    }
+}

--- a/Picea.Abies.Testing/TestHarness.cs
+++ b/Picea.Abies.Testing/TestHarness.cs
@@ -8,12 +8,19 @@ namespace Picea.Abies.Testing;
 public sealed class TestHarness<TProgram, TModel, TArgument>
     where TProgram : Program<TModel, TArgument>
 {
-    private const int MaxBatchDepth = 4_096;
+    private const int _maxBatchDepth = 4_096;
     private readonly Queue<Command> _pendingCommands = new();
     private readonly Dictionary<Type, Func<Command, IReadOnlyList<Message>>> _commandMocks = new();
     private readonly List<Type> _mockRegistrationOrder = [];
+    private readonly List<TestHarnessMessageHistoryEntry> _messageHistory = [];
+    private readonly List<TestHarnessDecisionHistoryEntry> _decisionHistory = [];
+    private readonly List<TestHarnessCommandHistoryEntry> _commandHistory = [];
+    private readonly List<TestHarnessReplayMetadataV1> _replayMetadataHistory = [];
     private readonly TestHarnessOptions _options;
     private int _transitionCount;
+    private int _messageSequence;
+    private int _decisionSequence;
+    private int _commandSequence;
 
     private TestHarness(TModel initialModel, TestHarnessOptions options)
     {
@@ -35,6 +42,26 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
     /// Number of queued commands waiting to be drained.
     /// </summary>
     public int PendingCommandCount => _pendingCommands.Count;
+
+    /// <summary>
+    /// Ordered history of messages processed by the harness.
+    /// </summary>
+    public IReadOnlyList<TestHarnessMessageHistoryEntry> MessageHistory => _messageHistory;
+
+    /// <summary>
+    /// Ordered history of Decide outputs produced for processed messages.
+    /// </summary>
+    public IReadOnlyList<TestHarnessDecisionHistoryEntry> DecisionHistory => _decisionHistory;
+
+    /// <summary>
+    /// Ordered history of command queue stages.
+    /// </summary>
+    public IReadOnlyList<TestHarnessCommandHistoryEntry> CommandHistory => _commandHistory;
+
+    /// <summary>
+    /// Ordered metadata for replay sessions executed by this harness.
+    /// </summary>
+    public IReadOnlyList<TestHarnessReplayMetadataV1> ReplayMetadataHistory => _replayMetadataHistory;
 
     /// <summary>
     /// Creates a harness from the program's initial state and initial command.
@@ -87,6 +114,17 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
     }
 
     /// <summary>
+    /// Serializes a replay session using the harness source-generated JSON context.
+    /// </summary>
+    /// <param name="session">The replay session to serialize.</param>
+    /// <returns>Serialized JSON payload.</returns>
+    public static string SerializeReplaySession(TestHarnessReplaySessionV1 session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        return JsonSerializer.Serialize(session, TestHarnessReplayJsonContext.Default.TestHarnessReplaySessionV1);
+    }
+
+    /// <summary>
     /// Replays a validated session by mapping each entry to a domain message and dispatching it in sequence order.
     /// </summary>
     /// <param name="session">The replay session to execute.</param>
@@ -101,6 +139,7 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
         ArgumentNullException.ThrowIfNull(mapEntryToMessage);
 
         session.Validate();
+        _replayMetadataHistory.Add(session.Metadata);
 
         for (var index = 0; index < session.Entries.Count; index++)
         {
@@ -108,7 +147,7 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
             var message = mapEntryToMessage(entry) ?? throw new InvalidOperationException(
                 $"Session entry at index {index} ({entry.MessageType}) was mapped to null.");
 
-            Dispatch(message);
+            DispatchCore(message, TestHarnessMessageSource.Replay);
         }
     }
 
@@ -123,6 +162,64 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
     {
         var session = LoadReplaySession(sessionJson);
         ReplaySession(session, mapEntryToMessage);
+    }
+
+    /// <summary>
+    /// Exports recorded message history to deterministic replay schema v1.
+    /// </summary>
+    /// <param name="mapEntryPayload">Maps one history entry into a replay payload object.</param>
+    /// <param name="mapEntryMessageType">Optional message type mapper. Defaults to the recorded CLR type name.</param>
+    /// <param name="metadata">Optional replay metadata. Defaults to harness-generated metadata.</param>
+    /// <param name="sourceFilter">Optional source filter when exporting only dispatch or replay-origin messages.</param>
+    /// <returns>A validated replay session payload.</returns>
+    public TestHarnessReplaySessionV1 ExportReplaySession(
+        Func<TestHarnessMessageHistoryEntry, JsonElement> mapEntryPayload,
+        Func<TestHarnessMessageHistoryEntry, string>? mapEntryMessageType = null,
+        TestHarnessReplayMetadataV1? metadata = null,
+        TestHarnessMessageSource? sourceFilter = null)
+    {
+        ArgumentNullException.ThrowIfNull(mapEntryPayload);
+
+        var selectedEntries = sourceFilter is null
+            ? _messageHistory
+            : _messageHistory.Where(entry => entry.Source == sourceFilter.Value).ToList();
+
+        var replayEntries = selectedEntries
+            .Select((entry, index) => new TestHarnessReplayEntryV1
+            {
+                Sequence = index,
+                MessageType = mapEntryMessageType?.Invoke(entry) ?? entry.MessageType,
+                Payload = mapEntryPayload(entry)
+            })
+            .ToArray();
+
+        var session = new TestHarnessReplaySessionV1
+        {
+            SchemaVersion = TestHarnessReplaySchema.Version1,
+            Metadata = metadata ?? CreateDefaultReplayMetadata(),
+            Entries = replayEntries
+        };
+
+        session.Validate();
+        return session;
+    }
+
+    /// <summary>
+    /// Exports message history to deterministic replay schema v1 JSON.
+    /// </summary>
+    /// <param name="mapEntryPayload">Maps one history entry into a replay payload object.</param>
+    /// <param name="mapEntryMessageType">Optional message type mapper. Defaults to the recorded CLR type name.</param>
+    /// <param name="metadata">Optional replay metadata. Defaults to harness-generated metadata.</param>
+    /// <param name="sourceFilter">Optional source filter when exporting only dispatch or replay-origin messages.</param>
+    /// <returns>Serialized replay session JSON.</returns>
+    public string ExportReplaySessionJson(
+        Func<TestHarnessMessageHistoryEntry, JsonElement> mapEntryPayload,
+        Func<TestHarnessMessageHistoryEntry, string>? mapEntryMessageType = null,
+        TestHarnessReplayMetadataV1? metadata = null,
+        TestHarnessMessageSource? sourceFilter = null)
+    {
+        var session = ExportReplaySession(mapEntryPayload, mapEntryMessageType, metadata, sourceFilter);
+        return SerializeReplaySession(session);
     }
 
     /// <summary>
@@ -185,7 +282,7 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
 
         foreach (var message in messages)
         {
-            DispatchCore(message);
+            DispatchCore(message, TestHarnessMessageSource.Dispatch);
         }
     }
 
@@ -207,6 +304,7 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
             }
 
             var command = _pendingCommands.Dequeue();
+            RecordCommandHistory(command, TestHarnessCommandStage.Dequeued);
             var mock = ResolveCommandMock(command.GetType());
             if (mock is null)
             {
@@ -220,8 +318,10 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
         }
     }
 
-    private void DispatchCore(Message message)
+    private void DispatchCore(Message message, TestHarnessMessageSource source)
     {
+        RecordMessageHistory(message, source);
+
         if (TProgram.IsTerminal(Model))
         {
             return;
@@ -230,12 +330,14 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
         var decision = TProgram.Decide(Model, message);
         if (decision.IsErr)
         {
+            RecordDecisionHistory(message, decision.Error, isError: true);
             ApplyTransition(decision.Error);
             return;
         }
 
         foreach (var decidedEvent in decision.Value)
         {
+            RecordDecisionHistory(message, decidedEvent, isError: false);
             ApplyTransition(decidedEvent);
         }
     }
@@ -270,10 +372,10 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
 
             if (current is Command.Batch batch)
             {
-                if (depth >= MaxBatchDepth)
+                if (depth >= _maxBatchDepth)
                 {
                     throw new InvalidOperationException(
-                        $"Command batch nesting exceeded {MaxBatchDepth}. The command graph is likely malformed.");
+                    $"Command batch nesting exceeded {_maxBatchDepth}. The command graph is likely malformed.");
                 }
 
                 for (var i = batch.Commands.Count - 1; i >= 0; i--)
@@ -285,7 +387,56 @@ public sealed class TestHarness<TProgram, TModel, TArgument>
             }
 
             _pendingCommands.Enqueue(current);
+            RecordCommandHistory(current, TestHarnessCommandStage.Enqueued);
         }
+    }
+
+    private void RecordMessageHistory(Message message, TestHarnessMessageSource source)
+    {
+        var entry = new TestHarnessMessageHistoryEntry(
+            Sequence: _messageSequence,
+            Message: message,
+            MessageType: message.GetType().Name,
+            Source: source);
+
+        _messageHistory.Add(entry);
+        _messageSequence++;
+    }
+
+    private void RecordDecisionHistory(Message triggerMessage, Message outputMessage, bool isError)
+    {
+        var entry = new TestHarnessDecisionHistoryEntry(
+            Sequence: _decisionSequence,
+            TriggerMessage: triggerMessage,
+            OutputMessage: outputMessage,
+            IsError: isError);
+
+        _decisionHistory.Add(entry);
+        _decisionSequence++;
+    }
+
+    private void RecordCommandHistory(Command command, TestHarnessCommandStage stage)
+    {
+        var entry = new TestHarnessCommandHistoryEntry(
+            Sequence: _commandSequence,
+            Command: command,
+            Stage: stage);
+
+        _commandHistory.Add(entry);
+        _commandSequence++;
+    }
+
+    private static TestHarnessReplayMetadataV1 CreateDefaultReplayMetadata()
+    {
+        var programVersion = typeof(TProgram).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+        return new TestHarnessReplayMetadataV1
+        {
+            SessionId = Guid.NewGuid().ToString("N"),
+            ProgramName = typeof(TProgram).FullName ?? typeof(TProgram).Name,
+            ProgramVersion = programVersion,
+            RecordedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        };
     }
 
     private Func<Command, IReadOnlyList<Message>>? ResolveCommandMock(Type commandType)

--- a/Picea.Abies.Testing/TestHarnessExecutionHistory.cs
+++ b/Picea.Abies.Testing/TestHarnessExecutionHistory.cs
@@ -1,0 +1,70 @@
+namespace Picea.Abies.Testing;
+
+/// <summary>
+/// Origin of a message processed by <see cref="TestHarness{TProgram,TModel,TArgument}"/>.
+/// </summary>
+public enum TestHarnessMessageSource
+{
+    /// <summary>
+    /// Message came from a direct dispatch through the harness API.
+    /// </summary>
+    Dispatch = 0,
+
+    /// <summary>
+    /// Message came from deterministic replay session execution.
+    /// </summary>
+    Replay = 1
+}
+
+/// <summary>
+/// Command lifecycle stage captured by the harness.
+/// </summary>
+public enum TestHarnessCommandStage
+{
+    /// <summary>
+    /// Command was enqueued and is pending drain.
+    /// </summary>
+    Enqueued = 0,
+
+    /// <summary>
+    /// Command was dequeued for mock execution.
+    /// </summary>
+    Dequeued = 1
+}
+
+/// <summary>
+/// Recorded message processed by the harness.
+/// </summary>
+/// <param name="Sequence">Monotonic sequence number.</param>
+/// <param name="Message">The message instance that was processed.</param>
+/// <param name="MessageType">The CLR type name of <paramref name="Message"/>.</param>
+/// <param name="Source">Whether this message came from dispatch or replay.</param>
+public sealed record TestHarnessMessageHistoryEntry(
+    int Sequence,
+    Message Message,
+    string MessageType,
+    TestHarnessMessageSource Source);
+
+/// <summary>
+/// Recorded Decide output produced for a dispatched message.
+/// </summary>
+/// <param name="Sequence">Monotonic sequence number.</param>
+/// <param name="TriggerMessage">Input message passed to Decide.</param>
+/// <param name="OutputMessage">Event or error message emitted by Decide.</param>
+/// <param name="IsError">True when <paramref name="OutputMessage"/> came from the error branch.</param>
+public sealed record TestHarnessDecisionHistoryEntry(
+    int Sequence,
+    Message TriggerMessage,
+    Message OutputMessage,
+    bool IsError);
+
+/// <summary>
+/// Recorded command queue event.
+/// </summary>
+/// <param name="Sequence">Monotonic sequence number.</param>
+/// <param name="Command">Command instance that entered this stage.</param>
+/// <param name="Stage">Current command stage.</param>
+public sealed record TestHarnessCommandHistoryEntry(
+    int Sequence,
+    Command Command,
+    TestHarnessCommandStage Stage);


### PR DESCRIPTION
## 📝 Description

### What
Implements Issue #165 Phase 3 by extending `Picea.Abies.Testing` with replay diagnostics and export/recording APIs, and adds an initial 10k replay benchmark.

### Why
Phase 1-2 established harness dispatch/replay foundations. Phase 3 adds observability and export capabilities needed for robust regression authoring and replay-driven test workflows.

### How
- Added execution-history contracts for test diagnostics:
  - `TestHarnessMessageHistoryEntry`
  - `TestHarnessDecisionHistoryEntry`
  - `TestHarnessCommandHistoryEntry`
  - `TestHarnessMessageSource`, `TestHarnessCommandStage`
- Extended `TestHarness<TProgram,TModel,TArgument>` with:
  - Message/decision/command/replay metadata history APIs
  - Deterministic replay export APIs:
    - `ExportReplaySession(...)`
    - `ExportReplaySessionJson(...)`
  - Replay serialization helper:
    - `SerializeReplaySession(...)`
- Added Phase 3 tests for diagnostics/export behavior:
  - `Picea.Abies.Testing.Tests/TestHarnessReplayDiagnosticsTests.cs`
- Added initial BenchmarkDotNet replay benchmark:
  - `Picea.Abies.Benchmarks/TestHarnessReplayBenchmarks.cs`
  - wired `Picea.Abies.Benchmarks` to reference `Picea.Abies.Testing`
- Included fix for benchmark runtime validation by making benchmark class non-sealed.

## 🔗 Related Issues
Progresses #165

## ✅ Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ⚡ Performance improvement
- [x] ✅ Test update

## 🧪 Testing
### Test Coverage
- [x] Unit tests added/updated
- [x] Benchmarks added/updated

### Testing Details
- `dotnet test --project Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj -v minimal`
- `dotnet build Picea.Abies.Benchmarks/Picea.Abies.Benchmarks.csproj -v minimal`

## ✨ Changes Made
- Added harness execution history model and surfaced read-only diagnostic histories
- Added deterministic export APIs to generate replay schema v1 payloads from recorded harness history
- Added replay diagnostics test suite (22 total tests passing in project)
- Added baseline benchmark for load+replay throughput at 10k messages

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Tests added/updated and passing
