### PR TITLE
test(runtime): Prove UrlChanged dispatch is not HOL-blocked

### DIFF
--- a/Picea.Abies.Tests/RuntimeIsolationAndSubscriptionFaultTests.cs
+++ b/Picea.Abies.Tests/RuntimeIsolationAndSubscriptionFaultTests.cs
@@ -109,30 +109,39 @@ public sealed class RuntimeIsolationAndSubscriptionFaultTests
     [Test]
     public async Task Runtime_DoesNotBlockUrlChangedDispatch_WhileSlowCommandIsInFlight()
     {
+        var slowInterpreterStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSlowInterpreter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
         static async ValueTask<Result<Message[], PipelineError>> Interpreter(Command command)
+        {
+            return Result<Message[], PipelineError>.Ok([]);
+        }
+
+        async ValueTask<Result<Message[], PipelineError>> ControlledInterpreter(Command command)
         {
             if (command is DelayCommand)
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                slowInterpreterStarted.TrySetResult();
+                await releaseSlowInterpreter.Task;
             }
 
-            return Result<Message[], PipelineError>.Ok([]);
+            return await Interpreter(command);
         }
 
         using var runtime = await Runtime<NavigationDispatchProbeProgram, NavigationDispatchProbeModel, Unit>.Start(
             _ => { },
-            Interpreter);
+            ControlledInterpreter);
 
         var slowDispatch = runtime.Dispatch(new BeginSlowWorkflow());
-        await Task.Delay(TimeSpan.FromMilliseconds(25));
+        await slowInterpreterStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
-        var stopwatch = Stopwatch.StartNew();
-        await runtime.Dispatch(new UrlChanged(new Url(["articles"], new Dictionary<string, string>(), Option<string>.None)));
-        stopwatch.Stop();
+        await runtime.Dispatch(new UrlChanged(new Url(["articles"], new Dictionary<string, string>(), Option<string>.None)))
+            .AsTask()
+            .WaitAsync(TimeSpan.FromMilliseconds(200));
 
+        releaseSlowInterpreter.TrySetResult();
         await slowDispatch;
 
-        await Assert.That(stopwatch.ElapsedMilliseconds < 200).IsTrue();
         await Assert.That(runtime.Model.UrlChangedCount).IsEqualTo(1);
         await Assert.That(runtime.Model.SlowCount).IsEqualTo(1);
     }

--- a/Picea.Abies.Tests/RuntimeIsolationAndSubscriptionFaultTests.cs
+++ b/Picea.Abies.Tests/RuntimeIsolationAndSubscriptionFaultTests.cs
@@ -106,9 +106,42 @@ public sealed class RuntimeIsolationAndSubscriptionFaultTests
         await Assert.That(runtime.Model.SlowCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task Runtime_DoesNotBlockUrlChangedDispatch_WhileSlowCommandIsInFlight()
+    {
+        static async ValueTask<Result<Message[], PipelineError>> Interpreter(Command command)
+        {
+            if (command is DelayCommand)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }
+
+            return Result<Message[], PipelineError>.Ok([]);
+        }
+
+        using var runtime = await Runtime<NavigationDispatchProbeProgram, NavigationDispatchProbeModel, Unit>.Start(
+            _ => { },
+            Interpreter);
+
+        var slowDispatch = runtime.Dispatch(new BeginSlowWorkflow());
+        await Task.Delay(TimeSpan.FromMilliseconds(25));
+
+        var stopwatch = Stopwatch.StartNew();
+        await runtime.Dispatch(new UrlChanged(new Url(["articles"], new Dictionary<string, string>(), Option<string>.None)));
+        stopwatch.Stop();
+
+        await slowDispatch;
+
+        await Assert.That(stopwatch.ElapsedMilliseconds < 200).IsTrue();
+        await Assert.That(runtime.Model.UrlChangedCount).IsEqualTo(1);
+        await Assert.That(runtime.Model.SlowCount).IsEqualTo(1);
+    }
+
     private sealed record DecisionErrModel(int TriggerCount, int DecisionErrCount, string? LastError);
 
     private sealed record DispatchProbeModel(int FastCount, int SlowCount);
+
+    private sealed record NavigationDispatchProbeModel(int UrlChangedCount, int SlowCount);
 
     private sealed record TriggerDecisionErr : Message;
 
@@ -184,6 +217,37 @@ public sealed class RuntimeIsolationAndSubscriptionFaultTests
             new("Dispatch Probe", div([], [text($"fast:{model.FastCount};slow:{model.SlowCount}")]));
 
         public static Subscription Subscriptions(DispatchProbeModel model) =>
+            SubscriptionModule.None;
+    }
+
+    private sealed class NavigationDispatchProbeProgram : Program<NavigationDispatchProbeModel, Unit>
+    {
+        public static (NavigationDispatchProbeModel, Command) Initialize(Unit argument) =>
+            (new NavigationDispatchProbeModel(0, 0), Commands.None);
+
+        public static (NavigationDispatchProbeModel, Command) Transition(NavigationDispatchProbeModel model, Message message) =>
+            message switch
+            {
+                BeginSlowWorkflow => (model, new DelayCommand()),
+                SlowObserved => (model with { SlowCount = model.SlowCount + 1 }, Commands.None),
+                UrlChanged => (model with { UrlChangedCount = model.UrlChangedCount + 1 }, Commands.None),
+                _ => (model, Commands.None)
+            };
+
+        public static Result<Message[], Message> Decide(NavigationDispatchProbeModel _, Message command) =>
+            command switch
+            {
+                BeginSlowWorkflow => Result<Message[], Message>.Ok([new BeginSlowWorkflow(), new SlowObserved()]),
+                UrlChanged changed => Result<Message[], Message>.Ok([changed]),
+                _ => Result<Message[], Message>.Ok([command])
+            };
+
+        public static bool IsTerminal(NavigationDispatchProbeModel _) => false;
+
+        public static Document View(NavigationDispatchProbeModel model) =>
+            new("Navigation Dispatch Probe", div([], [text($"url:{model.UrlChangedCount};slow:{model.SlowCount}")]));
+
+        public static Subscription Subscriptions(NavigationDispatchProbeModel model) =>
             SubscriptionModule.None;
     }
 


### PR DESCRIPTION
## 📝 Description

### What
Add a navigation-specific regression test proving `UrlChanged` dispatch is not blocked while another command is awaiting interpreter I/O.

### Why
Issue #245 identified a potential head-of-line blocking risk from runtime dispatch gating. Current runtime code scopes the gate to the decision section, but we were missing explicit `UrlChanged` regression coverage to prevent future regressions.

### How
- Added `Runtime_DoesNotBlockUrlChangedDispatch_WhileSlowCommandIsInFlight` in `RuntimeIsolationAndSubscriptionFaultTests`
- The test starts a slow command dispatch, then dispatches `UrlChanged` and asserts prompt completion plus model updates

## 🔗 Related Issues
Closes #245

## ✅ Type of Change
- [x] ✅ Test update

## 🧪 Testing
### Test Coverage
- [x] Unit tests added/updated

### Testing Details
- Ran: `dotnet test --project Picea.Abies.Tests/Picea.Abies.Tests.csproj -v minimal`
- Result: 224 passed, 0 failed

## ✨ Changes Made
- Added UrlChanged-in-flight non-blocking regression test in `Picea.Abies.Tests/RuntimeIsolationAndSubscriptionFaultTests.cs`

## 🔍 Code Review Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code performed
- [x] Code changes generate no new warnings
- [x] Tests added/updated and passing
