### PR TITLE
ci(release): Publish stable NuGet versions from release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Set version
         id: version
         run: |
-          VERSION=$(nbgv get-version -v AssemblyInformationalVersion)
+          # Public release mode ensures tag builds produce stable NuGet versions without commit suffixes.
+          VERSION=$(nbgv get-version --public-release=true -v NuGetPackageVersion)
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies


### PR DESCRIPTION
## What\nUse NBGV public-release mode in release workflow and set package version from NuGetPackageVersion instead of AssemblyInformationalVersion.\n\n## Why\nAssemblyInformationalVersion produced prerelease-like package versions (for example 2.0.3-g<sha>) for tag releases.\n\n## How\n- In release workflow Set version step, use:\n  nbgv get-version --public-release=true -v NuGetPackageVersion\n- Keep all existing build, test, pack, and publish steps unchanged.\n\n## Validation\n- YAML parse: ok\n- Local NBGV check:\n  - public release: 2.0.3\n  - default mode: 2.0.3-gf8fe776ed7\n