### PR TITLE
ci(release): Use SimpleVersion for stable NuGet package versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Set version
         id: version
         run: |
-          # Public release mode ensures tag builds produce stable NuGet versions without commit suffixes.
-          VERSION=$(nbgv get-version --public-release=true -v NuGetPackageVersion)
+          # Use SimpleVersion to force stable package versions from release tags (for example, 2.0.4).
+          VERSION=$(nbgv get-version -v SimpleVersion)
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies


### PR DESCRIPTION
## What\nUpdate release workflow to set package VERSION from NBGV SimpleVersion.\n\n## Why\nRecent tag run produced packages like 2.0.4-g<sha> despite public-release flag usage. SimpleVersion guarantees stable SemVer (for example, 2.0.4) for package publishing.\n\n## How\n- In .github/workflows/release.yml Set version step:\n  - from: nbgv ... NuGetPackageVersion\n  - to: nbgv ... SimpleVersion\n\n## Validation\n- YAML parse: ok\n- nbgv get-version -v SimpleVersion => 2.0.4\n- nbgv get-version -v NuGetPackageVersion => 2.0.4-g5b982117ec\n