### PR TITLE
ci(release): Gate NuGet publish to v* tag refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,4 +90,5 @@ jobs:
         run: dotnet pack ./Metapackages/Abies.Server/Abies.Server.csproj --configuration Release --output ./nupkg /p:PackageVersion=${{ steps.version.outputs.VERSION }}
 
       - name: Publish to NuGet
+        if: startsWith(github.ref, 'refs/tags/v')
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What\nAdd a tag-ref guard on the NuGet publish step in release workflow.\n\n## Why\nA review comment correctly pointed out that workflow_dispatch can run on non-tag refs. Without a guard, branch/manual runs can publish stable-looking versions and collide with real tag releases.\n\n## Change\n- Added  to Publish to NuGet step.\n\n## Validation\n- YAML parse: ok\n- Diff scope: one-line functional guard only\n