### PR TITLE
ci(release): Derive package version from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,13 @@ jobs:
       - name: Set version
         id: version
         run: |
-          # Use SimpleVersion to force stable package versions from release tags (for example, 2.0.4).
-          VERSION=$(nbgv get-version -v SimpleVersion)
+          # For tag runs, package version must match the tag (v2.0.4 -> 2.0.4).
+          # For workflow_dispatch on non-tag refs, fall back to a stable computed version.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION=$(nbgv get-version -v SimpleVersion)
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies


### PR DESCRIPTION
## What\nMake release workflow derive package version from tag name on tag runs (vX.Y.Z => X.Y.Z).\n\n## Why\nEnsures the next release version is exactly the tagged version (for example, 2.0.4), independent of commit height math.\n\n## How\n- In Set version step:\n  - if tag ref: parse version from GITHUB_REF\n  - else (workflow_dispatch non-tag): fallback to nbgv SimpleVersion\n\n## Validation\n- YAML parse: ok\n- Publish step already guarded to v* tags only\n