### PR TITLE
ci(release): Stamp NBGV from tag and enable PublicRelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
           # For workflow_dispatch on non-tag refs, fall back to a stable computed version.
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+            nbgv set-version "$VERSION"
+            echo "PublicRelease=true" >> "$GITHUB_ENV"
           else
             VERSION=$(nbgv get-version -v SimpleVersion)
           fi


### PR DESCRIPTION
## What
For tag-triggered releases, stamp NBGV to the tag version and enable `PublicRelease=true`.

## Why
Even with tag parsing and `/p:Version`, release run `25485009202` still produced `2.0.8-g...` packages due NBGV defaults. Local repro proved the working combination is:
- `nbgv set-version <tag-version>`
- `PublicRelease=true`

## Change
- In release workflow `Set version` step, for tag refs:
  - `VERSION="${GITHUB_REF#refs/tags/v}"`
  - `nbgv set-version "$VERSION"`
  - `echo "PublicRelease=true" >> "$GITHUB_ENV"`

## Validation
- YAML parse: ok
- Diff scope: two-line adjustment in version step
