### PR TITLE
feat(testing): Complete visual regression harness reintroduction

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Detect visual regression tests
         id: detect_visual_tests
         run: |
-          if rg -n "VisualRegression_" Picea.Abies.Conduit.Tests >/dev/null 2>&1; then
+          if grep -rqs "VisualRegression_" Picea.Abies.Conduit.Tests; then
             echo "has_visual_tests=true" >> "$GITHUB_OUTPUT"
             echo "✅ Visual regression tests detected"
           else
@@ -56,10 +56,13 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          dotnet tool install --global Microsoft.Playwright.CLI || true
-          pwsh Picea.Abies.Conduit.Tests/bin/Debug/net10.0/playwright.ps1 install chromium --with-deps || \
-          dotnet run --project Picea.Abies.Conduit.Tests --no-build -- playwright install chromium --with-deps || \
-          npx playwright install chromium --with-deps || \
+          PW_DIR=Picea.Abies.Conduit.Tests/bin/Debug/net10.0
+          # Prefer the pwsh launcher (present on GitHub-hosted runners); fall back to
+          # the version-matched bundled Node CLI so the install also works on runners
+          # without PowerShell. Both install the browser revision the referenced
+          # Microsoft.Playwright package expects.
+          pwsh "$PW_DIR/playwright.ps1" install chromium --with-deps || \
+          node "$PW_DIR/.playwright/package/cli.js" install chromium --with-deps || \
           true
 
       # Run pixel snapshot tests — failures generate .actual.png + .diff.png artifacts
@@ -74,10 +77,9 @@ jobs:
           dotnet test \
             --project Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj \
             --no-build \
-            --verbosity normal \
-            --filter "FullyQualifiedName~VisualRegression" \
-            --logger "trx;LogFileName=visual-regression.trx" \
-            --results-directory TestResults/visual-regression
+            --results-directory TestResults/visual-regression \
+            -- --treenode-filter "/*/*/*/VisualRegression*" \
+            --report-trx --report-trx-filename visual-regression.trx
 
       # Upload baselines + actuals + diffs so GitHub's image compare works in the PR.
       # Reviewers can open the artifact and compare images side-by-side.

--- a/Picea.Abies.Cli/Picea.Abies.Cli.csproj
+++ b/Picea.Abies.Cli/Picea.Abies.Cli.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Picea.Abies.Cli</PackageId>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>abies</ToolCommandName>
+    <PackageTags>testing;visual-regression;playwright;snapshot</PackageTags>
+    <Description>CLI tooling for Abies visual baseline workflows.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Picea.Abies.Cli/Program.cs
+++ b/Picea.Abies.Cli/Program.cs
@@ -1,0 +1,7 @@
+namespace Picea.Abies.Cli;
+
+public static class Program
+{
+    public static Task<int> Main(string[] args) =>
+        VisualCliApp.InvokeAsync(args);
+}

--- a/Picea.Abies.Cli/VisualCliApp.cs
+++ b/Picea.Abies.Cli/VisualCliApp.cs
@@ -1,0 +1,330 @@
+using System.CommandLine;
+using System.Text;
+
+namespace Picea.Abies.Cli;
+
+public static class VisualCliApp
+{
+    public static Task<int> InvokeAsync(string[] args, TextWriter? output = null, TextWriter? error = null)
+    {
+        var resolvedOutput = output ?? Console.Out;
+        var resolvedError = error ?? Console.Error;
+        var root = BuildRootCommand(resolvedOutput, resolvedError);
+
+        return root.Parse(args).InvokeAsync();
+    }
+
+    public static RootCommand BuildRootCommand(TextWriter output, TextWriter error)
+    {
+        var root = new RootCommand("Abies testing CLI");
+        var visual = new Command("visual", "Visual baseline workflows");
+
+        visual.Add(BuildAcceptCommand(output, error));
+        visual.Add(BuildStatusCommand(output));
+        visual.Add(BuildReportCommand(output));
+
+        root.Add(visual);
+        return root;
+    }
+
+    private static Command BuildAcceptCommand(TextWriter output, TextWriter error)
+    {
+        var command = new Command("accept", "Accept one visual snapshot or all pending snapshots");
+        var snapshotArgument = new Argument<string?>("snapshot")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        var allOption = new Option<bool>("--all")
+        {
+            Description = "Accept all pending snapshots."
+        };
+        var artifactsOption = new Option<string>("--artifacts")
+        {
+            Description = "Artifacts directory containing *.actual.png files.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultArtifactsDirectory
+        };
+        var baselinesOption = new Option<string>("--baselines")
+        {
+            Description = "Baselines directory receiving accepted snapshots.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultBaselinesDirectory
+        };
+
+        command.Add(snapshotArgument);
+        command.Add(allOption);
+        command.Add(artifactsOption);
+        command.Add(baselinesOption);
+
+        command.SetAction(parseResult =>
+        {
+            var snapshot = parseResult.GetValue(snapshotArgument);
+            var all = parseResult.GetValue(allOption);
+            var artifactsDirectory = parseResult.GetValue(artifactsOption)!;
+            var baselinesDirectory = parseResult.GetValue(baselinesOption)!;
+
+            if (all)
+            {
+                if (string.IsNullOrWhiteSpace(snapshot) is false)
+                {
+                    error.WriteLine("Do not pass <snapshot> when using --all.");
+                    return 1;
+                }
+
+                return VisualBaselineWorkflow.AcceptAll(artifactsDirectory, baselinesDirectory, output);
+            }
+
+            if (string.IsNullOrWhiteSpace(snapshot))
+            {
+                error.WriteLine("Specify <snapshot> or use --all.");
+                return 1;
+            }
+
+            return VisualBaselineWorkflow.AcceptSnapshot(snapshot, artifactsDirectory, baselinesDirectory, output);
+        });
+
+        return command;
+    }
+
+    private static Command BuildStatusCommand(TextWriter output)
+    {
+        var command = new Command("status", "Show pending visual snapshot mismatches.");
+        var artifactsOption = new Option<string>("--artifacts")
+        {
+            Description = "Artifacts directory containing *.actual.png files.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultArtifactsDirectory
+        };
+        var baselinesOption = new Option<string>("--baselines")
+        {
+            Description = "Baselines directory used for resolved target paths.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultBaselinesDirectory
+        };
+
+        command.Add(artifactsOption);
+        command.Add(baselinesOption);
+
+        command.SetAction(parseResult =>
+        {
+            var artifactsDirectory = parseResult.GetValue(artifactsOption)!;
+            var baselinesDirectory = parseResult.GetValue(baselinesOption)!;
+            var status = VisualBaselineWorkflow.GetStatus(artifactsDirectory, baselinesDirectory);
+            output.WriteLine($"Pending visual snapshots: {status.PendingCount}");
+
+            foreach (var pending in status.PendingSnapshots)
+            {
+                output.WriteLine($"- {pending.SnapshotName}");
+            }
+
+            return 0;
+        });
+
+        return command;
+    }
+
+    private static Command BuildReportCommand(TextWriter output)
+    {
+        var command = new Command("report", "Write a visual mismatch report to disk.");
+        var outputOption = new Option<string>("--output")
+        {
+            Description = "Output directory for the report.",
+            Required = true
+        };
+        var artifactsOption = new Option<string>("--artifacts")
+        {
+            Description = "Artifacts directory containing *.actual.png files.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultArtifactsDirectory
+        };
+        var baselinesOption = new Option<string>("--baselines")
+        {
+            Description = "Baselines directory used for resolved target paths.",
+            DefaultValueFactory = _ => VisualBaselineWorkflow.DefaultBaselinesDirectory
+        };
+
+        command.Add(outputOption);
+        command.Add(artifactsOption);
+        command.Add(baselinesOption);
+
+        command.SetAction(parseResult =>
+        {
+            var reportOutputDirectory = parseResult.GetValue(outputOption)!;
+            var artifactsDirectory = parseResult.GetValue(artifactsOption)!;
+            var baselinesDirectory = parseResult.GetValue(baselinesOption)!;
+            var reportPath = VisualBaselineWorkflow.WriteReport(artifactsDirectory, baselinesDirectory, reportOutputDirectory);
+            output.WriteLine($"Report written: {reportPath}");
+            return 0;
+        });
+
+        return command;
+    }
+}
+
+public sealed record PendingSnapshot(string SnapshotName, string ActualPath, string BaselinePath, string? DiffPath);
+
+public sealed record VisualStatus(int PendingCount, IReadOnlyList<PendingSnapshot> PendingSnapshots);
+
+public static class VisualBaselineWorkflow
+{
+    public const string DefaultArtifactsDirectory = "artifacts/visual";
+    public const string DefaultBaselinesDirectory = "baselines/visual";
+
+    public static int AcceptSnapshot(string snapshot, string artifactsDirectory, string baselinesDirectory, TextWriter output)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshot);
+
+        var actualPath = ResolveActualPath(snapshot, artifactsDirectory);
+        if (File.Exists(actualPath) is false)
+        {
+            output.WriteLine($"Snapshot not found: {actualPath}");
+            return 1;
+        }
+
+        var baselinePath = ResolveBaselinePath(snapshot, baselinesDirectory);
+        EnsureParentDirectory(baselinePath);
+        File.Copy(actualPath, baselinePath, overwrite: true);
+
+        output.WriteLine($"Accepted: {Path.GetFileName(actualPath)} -> {baselinePath}");
+        return 0;
+    }
+
+    public static int AcceptAll(string artifactsDirectory, string baselinesDirectory, TextWriter output)
+    {
+        var status = GetStatus(artifactsDirectory, baselinesDirectory);
+        if (status.PendingCount == 0)
+        {
+            output.WriteLine("No pending visual snapshots.");
+            return 0;
+        }
+
+        foreach (var pending in status.PendingSnapshots)
+        {
+            EnsureParentDirectory(pending.BaselinePath);
+            File.Copy(pending.ActualPath, pending.BaselinePath, overwrite: true);
+            output.WriteLine($"Accepted: {pending.SnapshotName}");
+        }
+
+        output.WriteLine($"Accepted {status.PendingCount} snapshots.");
+        return 0;
+    }
+
+    public static VisualStatus GetStatus(string artifactsDirectory, string baselinesDirectory)
+    {
+        if (Directory.Exists(artifactsDirectory) is false)
+        {
+            return new VisualStatus(0, []);
+        }
+
+        var pending = Directory
+            .EnumerateFiles(artifactsDirectory, "*.actual.png", SearchOption.TopDirectoryOnly)
+            .Select(actualPath =>
+            {
+                var snapshotName = BuildSnapshotName(actualPath);
+                var baselinePath = Path.Combine(baselinesDirectory, snapshotName);
+                var diffPath = Path.Combine(artifactsDirectory, Path.GetFileNameWithoutExtension(snapshotName) + ".diff.png");
+
+                return new PendingSnapshot(
+                    snapshotName,
+                    actualPath,
+                    baselinePath,
+                    File.Exists(diffPath) ? diffPath : null);
+            })
+            .OrderBy(snapshot => snapshot.SnapshotName, StringComparer.Ordinal)
+            .ToArray();
+
+        return new VisualStatus(pending.Length, pending);
+    }
+
+    public static string WriteReport(string artifactsDirectory, string baselinesDirectory, string outputDirectory)
+    {
+        Directory.CreateDirectory(outputDirectory);
+
+        var status = GetStatus(artifactsDirectory, baselinesDirectory);
+        var reportPath = Path.Combine(outputDirectory, "visual-report.md");
+
+        var builder = new StringBuilder();
+        builder.AppendLine("# Visual Baseline Report");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated (UTC): {DateTimeOffset.UtcNow:O}");
+        builder.AppendLine($"- Artifacts directory: `{artifactsDirectory}`");
+        builder.AppendLine($"- Baselines directory: `{baselinesDirectory}`");
+        builder.AppendLine($"- Pending snapshots: **{status.PendingCount}**");
+        builder.AppendLine();
+
+        if (status.PendingCount == 0)
+        {
+            builder.AppendLine("No pending visual snapshots.");
+            File.WriteAllText(reportPath, builder.ToString(), Encoding.UTF8);
+            return reportPath;
+        }
+
+        builder.AppendLine("| Snapshot | Baseline | Actual | Diff |");
+        builder.AppendLine("|---|---|---|---|");
+
+        foreach (var pending in status.PendingSnapshots)
+        {
+            var baselineLink = BuildMarkdownLink(outputDirectory, pending.BaselinePath, "baseline");
+            var actualLink = BuildMarkdownLink(outputDirectory, pending.ActualPath, "actual");
+            var diffLink = pending.DiffPath is null
+                ? "(none)"
+                : BuildMarkdownLink(outputDirectory, pending.DiffPath, "diff");
+
+            builder.AppendLine($"| {pending.SnapshotName} | {baselineLink} | {actualLink} | {diffLink} |");
+        }
+
+        File.WriteAllText(reportPath, builder.ToString(), Encoding.UTF8);
+        return reportPath;
+    }
+
+    private static string BuildMarkdownLink(string reportDirectory, string path, string label)
+    {
+        if (File.Exists(path) is false)
+        {
+            return "(missing)";
+        }
+
+        var relativePath = Path.GetRelativePath(reportDirectory, path).Replace('\\', '/');
+        return $"[{label}]({relativePath})";
+    }
+
+    private static string ResolveActualPath(string snapshot, string artifactsDirectory)
+    {
+        if (Path.IsPathRooted(snapshot) && File.Exists(snapshot))
+        {
+            return snapshot;
+        }
+
+        var snapshotFileName = snapshot.EndsWith(".actual.png", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetFileName(snapshot)
+            : Path.GetFileNameWithoutExtension(snapshot) + ".actual.png";
+
+        return Path.Combine(artifactsDirectory, snapshotFileName);
+    }
+
+    private static string ResolveBaselinePath(string snapshot, string baselinesDirectory)
+    {
+        var snapshotName = snapshot.EndsWith(".actual.png", StringComparison.OrdinalIgnoreCase)
+            ? BuildSnapshotName(snapshot)
+            : Path.GetFileName(snapshot);
+
+        if (snapshotName.EndsWith(".png", StringComparison.OrdinalIgnoreCase) is false)
+        {
+            snapshotName += ".png";
+        }
+
+        return Path.Combine(baselinesDirectory, snapshotName);
+    }
+
+    private static string BuildSnapshotName(string actualPath)
+    {
+        var actualName = Path.GetFileName(actualPath);
+        return actualName.EndsWith(".actual.png", StringComparison.OrdinalIgnoreCase)
+            ? actualName.Replace(".actual.png", ".png", StringComparison.OrdinalIgnoreCase)
+            : actualName;
+    }
+
+    private static void EnsureParentDirectory(string filePath)
+    {
+        var parent = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrWhiteSpace(parent) is false)
+        {
+            Directory.CreateDirectory(parent);
+        }
+    }
+}

--- a/Picea.Abies.Conduit.Testing.E2E/VisualSnapshotExampleTests.cs
+++ b/Picea.Abies.Conduit.Testing.E2E/VisualSnapshotExampleTests.cs
@@ -1,0 +1,121 @@
+using System.Security.Cryptography;
+using Microsoft.Playwright;
+using Picea.Abies.Conduit.Testing.E2E.Fixtures;
+using Picea.Abies.Conduit.Testing.E2E.Helpers;
+
+namespace Picea.Abies.Conduit.Testing.E2E;
+
+[Category("E2E")]
+[ClassDataSource<ConduitAppFixture>(Shared = SharedType.Keyed, Key = "Conduit")]
+[NotInParallel("Conduit")]
+public sealed class VisualSnapshotExampleTests : IAsyncInitializer, IAsyncDisposable
+{
+    private readonly ConduitAppFixture _fixture;
+    private IPage _page = null!;
+
+    public VisualSnapshotExampleTests(ConduitAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _page = await _fixture.CreatePageAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _page.Context.DisposeAsync();
+    }
+
+    [Test]
+    public async Task HomeBanner_ShouldMatchSnapshot()
+    {
+        await _page.GotoAsync("/");
+        await _page.WaitForWasmReady();
+        await _page.WaitForSelectorAsync(".home-page", new() { Timeout = 15000 });
+
+        var banner = _page.Locator(".banner");
+        await AssertSnapshotAsync("home-banner", banner);
+    }
+
+    [Test]
+    public async Task HomeFeedToggle_ShouldMatchSnapshot()
+    {
+        await _page.GotoAsync("/");
+        await _page.WaitForWasmReady();
+        await _page.WaitForSelectorAsync(".home-page", new() { Timeout = 15000 });
+
+        var toggle = _page.Locator(".feed-toggle");
+        await AssertSnapshotAsync("home-feed-toggle", toggle);
+    }
+
+    private async Task AssertSnapshotAsync(string snapshotName, ILocator locator)
+    {
+        var baselinePath = GetBaselinePath(snapshotName);
+        var artifactsDirectory = GetArtifactsDirectory();
+        Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+        Directory.CreateDirectory(artifactsDirectory);
+
+        var actualBytes = await locator.ScreenshotAsync(new LocatorScreenshotOptions
+        {
+            Animations = ScreenshotAnimations.Disabled
+        });
+
+        if (File.Exists(baselinePath) is false)
+        {
+            await File.WriteAllBytesAsync(baselinePath, actualBytes);
+            return;
+        }
+
+        var baselineBytes = await File.ReadAllBytesAsync(baselinePath);
+        if (baselineBytes.AsSpan().SequenceEqual(actualBytes))
+        {
+            return;
+        }
+
+        var actualPath = Path.Combine(artifactsDirectory, $"{snapshotName}.actual.png");
+        await File.WriteAllBytesAsync(actualPath, actualBytes);
+
+        var baselineHash = ComputeSha256(baselineBytes);
+        var actualHash = ComputeSha256(actualBytes);
+
+        throw new InvalidOperationException(
+            $"Snapshot mismatch for '{snapshotName}'. Baseline: {baselinePath}. Actual: {actualPath}. " +
+            $"Baseline SHA256: {baselineHash}, Actual SHA256: {actualHash}.");
+    }
+
+    private static string GetBaselinePath(string snapshotName)
+    {
+        var root = FindSolutionDirectory();
+        return Path.Combine(root, "Picea.Abies.Conduit.Testing.E2E", "visual-baselines", "examples", $"{snapshotName}.png");
+    }
+
+    private static string GetArtifactsDirectory()
+    {
+        var root = FindSolutionDirectory();
+        return Path.Combine(root, "artifacts", "visual", "conduit-e2e");
+    }
+
+    private static string ComputeSha256(byte[] value)
+    {
+        var hash = SHA256.HashData(value);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string FindSolutionDirectory()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Picea.Abies.sln")))
+            {
+                return dir;
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find solution directory (containing Picea.Abies.sln).");
+    }
+}

--- a/Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj
+++ b/Picea.Abies.Conduit.Tests/Picea.Abies.Conduit.Tests.csproj
@@ -9,11 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageReference Include="TUnit" Version="1.19.57" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Conduit\Picea.Abies.Conduit.csproj" />
+    <ProjectReference Include="..\Picea.Abies.Conduit.App\Picea.Abies.Conduit.App.csproj" />
+    <ProjectReference Include="..\Picea.Abies.Testing\Picea.Abies.Testing.csproj" />
     <PackageReference Include="Picea" Version="1.0.0" />
   </ItemGroup>
 

--- a/Picea.Abies.Conduit.Tests/VisualRegressionTests.cs
+++ b/Picea.Abies.Conduit.Tests/VisualRegressionTests.cs
@@ -1,0 +1,106 @@
+// =============================================================================
+// Visual Regression Tests — Conduit static pages
+// =============================================================================
+// Pixel-snapshot regression coverage for deterministic Conduit views, driven by
+// the reusable visual harness in Picea.Abies.Testing (TestHarnessVisualExtensions).
+//
+// These render a Conduit page model with Playwright and diff the screenshot
+// against a committed baseline. Only the static, data-free pages (Login,
+// Register) are covered here so the baselines stay deterministic — they route
+// through Route.FromUrl with Commands.None and never fetch from the API.
+//
+// The CI gate (.github/workflows/visual-regression.yml) discovers these by the
+// "VisualRegression_" name prefix and runs them with
+// ABIES_ENABLE_PIXEL_SNAPSHOTS=1. Outside that gate (a normal `dotnet test`),
+// the tests skip rather than require Playwright browsers to be installed.
+// =============================================================================
+
+using Microsoft.Playwright;
+using Picea.Abies.Conduit.App;
+using Picea.Abies.Testing;
+using TUnit.Core.Exceptions;
+
+namespace Picea.Abies.Conduit.Tests;
+
+public sealed class VisualRegressionTests
+{
+    private const string PixelSnapshotsEnabledVariable = "ABIES_ENABLE_PIXEL_SNAPSHOTS";
+
+    [Test]
+    [Arguments("conduit-login", "/login")]
+    [Arguments("conduit-register", "/register")]
+    public async Task VisualRegression_StaticPage_MatchesBaseline(string snapshotName, string path)
+    {
+        SkipUnlessPixelSnapshotsEnabled();
+
+        var startup = new ConduitStartup(
+            ApiUrl: "https://api.conduit.local",
+            Session: null,
+            InitialUrl: Url.FromUri(new Uri($"https://conduit.local{path}")));
+
+        var harness = TestHarness<ConduitProgram, Model, ConduitStartup>.Create(startup);
+
+        await using var browser = await LaunchChromiumOrSkip();
+        var page = await browser.NewPageAsync();
+
+        var options = new VisualComparisonOptions(
+            ViewportWidth: 1024,
+            ViewportHeight: 768,
+            FullPage: true,
+            ArtifactDirectory: ArtifactsDirectory(),
+            Tolerance: VisualComparisonTolerance.Strict);
+
+        var result = await harness.CompareVisual(page, BaselinePath(snapshotName), options);
+
+        // First run on a fresh environment writes the baseline and passes; later
+        // runs diff against it. Either way a clean run is a match.
+        await Assert.That(result.IsMatch).IsTrue();
+    }
+
+    private static void SkipUnlessPixelSnapshotsEnabled()
+    {
+        if (Environment.GetEnvironmentVariable(PixelSnapshotsEnabledVariable) != "1")
+        {
+            throw new SkipTestException(
+                $"Visual regression tests are gated behind {PixelSnapshotsEnabledVariable}=1 " +
+                "(set by the Visual Regression CI workflow).");
+        }
+    }
+
+    private static async Task<IBrowser> LaunchChromiumOrSkip()
+    {
+        var playwright = await Playwright.CreateAsync();
+        try
+        {
+            return await playwright.Chromium.LaunchAsync();
+        }
+        catch (PlaywrightException ex) when (ex.Message.Contains("Executable doesn't exist", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new SkipTestException(
+                "Playwright Chromium is not installed. Install browsers (the CI workflow runs " +
+                "`playwright.ps1 install chromium`) before running visual regression tests.");
+        }
+    }
+
+    private static string BaselinePath(string snapshotName) =>
+        Path.Combine(SolutionDirectory(), "Picea.Abies.Conduit.Tests", "Snapshots", "visual", $"{snapshotName}.png");
+
+    private static string ArtifactsDirectory() =>
+        Path.Combine(SolutionDirectory(), "artifacts", "visual");
+
+    private static string SolutionDirectory()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Picea.Abies.sln")))
+            {
+                return dir;
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find solution directory (containing Picea.Abies.sln).");
+    }
+}

--- a/Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj
+++ b/Picea.Abies.Testing.Tests/Picea.Abies.Testing.Tests.csproj
@@ -10,10 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageReference Include="TUnit" Version="1.19.57" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies.Cli\Picea.Abies.Cli.csproj" />
     <ProjectReference Include="..\Picea.Abies.Testing\Picea.Abies.Testing.csproj" />
     <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
   </ItemGroup>

--- a/Picea.Abies.Testing.Tests/TestHarnessVisualTests.cs
+++ b/Picea.Abies.Testing.Tests/TestHarnessVisualTests.cs
@@ -1,0 +1,280 @@
+using Microsoft.Playwright;
+using Picea.Abies.DOM;
+using Picea.Abies.Subscriptions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Picea.Abies.Testing.Tests;
+
+public sealed class TestHarnessVisualTests
+{
+    [Test]
+    public async Task CompareVisual_WithPlaywrightPageOverload_CreatesBaselineAndMatchesSecondRun()
+    {
+        var harness = TestHarness<VisualProgram, VisualModel, Unit>.Create(Unit.Value);
+        var testRoot = CreateTestRoot();
+
+        await using var playwrightResources = await PlaywrightResources.CreateAsync();
+
+        try
+        {
+            var baselinePath = Path.Combine(testRoot, "baselines", "page-overload.png");
+            var options = new VisualComparisonOptions(
+                ViewportWidth: 320,
+                ViewportHeight: 180,
+                FullPage: false,
+                Tolerance: VisualComparisonTolerance.Strict);
+
+            var created = await harness.CompareVisual(playwrightResources.Page, baselinePath, options);
+            var compared = await harness.CompareVisual(playwrightResources.Page, baselinePath, options);
+
+            await Assert.That(created.BaselineCreated).IsTrue();
+            await Assert.That(created.IsMatch).IsTrue();
+            await Assert.That(compared.BaselineCreated).IsFalse();
+            await Assert.That(compared.IsMatch).IsTrue();
+            await Assert.That(compared.PixelErrorCount).IsEqualTo(0);
+            await Assert.That(File.Exists(baselinePath)).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(testRoot);
+        }
+    }
+
+    [Test]
+    public async Task CompareVisual_CreatesBaselineOnFirstRunAndPasses()
+    {
+        var harness = TestHarness<VisualProgram, VisualModel, Unit>.Create(Unit.Value);
+        var testRoot = CreateTestRoot();
+
+        try
+        {
+            var baselinePath = Path.Combine(testRoot, "baselines", "first-run.png");
+            var screenshot = CreateSolidPng(4, 4, new Rgba32(20, 40, 60, 255));
+
+            var result = harness.CompareVisual(screenshot, baselinePath);
+
+            await Assert.That(result.IsMatch).IsTrue();
+            await Assert.That(result.BaselineCreated).IsTrue();
+            await Assert.That(result.PixelErrorCount).IsEqualTo(0);
+            await Assert.That(File.Exists(baselinePath)).IsTrue();
+            await Assert.That(result.ActualPath).IsNull();
+            await Assert.That(result.DiffPath).IsNull();
+        }
+        finally
+        {
+            DeleteIfExists(testRoot);
+        }
+    }
+
+    [Test]
+    public async Task CompareVisual_MismatchProducesArtifactsAndAssertThrowsInStrictMode()
+    {
+        var harness = TestHarness<VisualProgram, VisualModel, Unit>.Create(Unit.Value);
+        var testRoot = CreateTestRoot();
+
+        try
+        {
+            var baselinePath = Path.Combine(testRoot, "baselines", "strict-mismatch.png");
+            var artifactDirectory = Path.Combine(testRoot, "artifacts", "visual");
+
+            var baseline = CreateSolidPng(4, 4, new Rgba32(0, 0, 0, 255));
+            var actual = CreateSolidPng(4, 4, new Rgba32(255, 255, 255, 255));
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            File.WriteAllBytes(baselinePath, baseline);
+
+            var result = harness.CompareVisual(
+                actual,
+                baselinePath,
+                new VisualComparisonOptions(
+                    ArtifactDirectory: artifactDirectory,
+                    Tolerance: VisualComparisonTolerance.Strict));
+
+            await Assert.That(result.IsMatch).IsFalse();
+            await Assert.That(result.BaselineCreated).IsFalse();
+            await Assert.That(result.PixelErrorCount).IsEqualTo(16);
+            await Assert.That(result.PixelErrorPercentage).IsEqualTo(1d);
+            await Assert.That(result.ActualPath).IsNotNull();
+            await Assert.That(result.DiffPath).IsNotNull();
+            await Assert.That(File.Exists(result.ActualPath!)).IsTrue();
+            await Assert.That(File.Exists(result.DiffPath!)).IsTrue();
+
+            var act = () => harness.AssertVisualMatch(
+                actual,
+                baselinePath,
+                new VisualComparisonOptions(
+                    ArtifactDirectory: artifactDirectory,
+                    Tolerance: VisualComparisonTolerance.Strict));
+
+            await Assert.That(act).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            DeleteIfExists(testRoot);
+        }
+    }
+
+    [Test]
+    public async Task CompareVisual_ToleranceAllowsControlledMismatch()
+    {
+        var harness = TestHarness<VisualProgram, VisualModel, Unit>.Create(Unit.Value);
+        var testRoot = CreateTestRoot();
+
+        try
+        {
+            var baselinePath = Path.Combine(testRoot, "baselines", "tolerance.png");
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            File.WriteAllBytes(baselinePath, CreateSolidPng(4, 4, new Rgba32(0, 0, 0, 255)));
+
+            var actual = CreateSolidPng(4, 4, new Rgba32(10, 10, 10, 255));
+            var strict = harness.CompareVisual(actual, baselinePath);
+            var tolerant = harness.CompareVisual(
+                actual,
+                baselinePath,
+                new VisualComparisonOptions(
+                    Tolerance: new VisualComparisonTolerance(
+                        MaxPixelErrorCount: 16,
+                        MaxPixelErrorPercentage: 1,
+                        MaxMeanError: 0.05,
+                        MaxAbsoluteError: 0.05,
+                        PerChannelThreshold: 16)));
+
+            await Assert.That(strict.IsMatch).IsFalse();
+            await Assert.That(tolerant.IsMatch).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(testRoot);
+        }
+    }
+
+    [Test]
+    public async Task CompareVisual_WhenImageDimensionsDiffer_Throws()
+    {
+        var harness = TestHarness<VisualProgram, VisualModel, Unit>.Create(Unit.Value);
+        var testRoot = CreateTestRoot();
+
+        try
+        {
+            var baselinePath = Path.Combine(testRoot, "baselines", "dimension-mismatch.png");
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            File.WriteAllBytes(baselinePath, CreateSolidPng(4, 4, new Rgba32(0, 0, 0, 255)));
+            var actual = CreateSolidPng(5, 4, new Rgba32(0, 0, 0, 255));
+
+            var act = () => harness.CompareVisual(actual, baselinePath);
+            await Assert.That(act).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            DeleteIfExists(testRoot);
+        }
+    }
+
+    private static string CreateTestRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "abies-visual-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    private static byte[] CreateSolidPng(int width, int height, Rgba32 color)
+    {
+        using var image = new Image<Rgba32>(width, height);
+
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                image[x, y] = color;
+            }
+        }
+
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return stream.ToArray();
+    }
+
+    private sealed record VisualModel(int Value);
+
+    private sealed class VisualProgram : Program<VisualModel, Unit>
+    {
+        public static (VisualModel, Command) Initialize(Unit argument) =>
+            (new VisualModel(0), Commands.None);
+
+        public static (VisualModel, Command) Transition(VisualModel model, Message message) =>
+            (model, Commands.None);
+
+        public static Result<Message[], Message> Decide(VisualModel state, Message command) =>
+            Result<Message[], Message>.Ok([command]);
+
+        public static bool IsTerminal(VisualModel state) => false;
+
+        public static Document View(VisualModel model) =>
+            new("Visual Test", Html.Elements.div([], [Html.Elements.text($"value:{model.Value}")]));
+
+        public static Subscription Subscriptions(VisualModel model) =>
+            new Subscription.None();
+    }
+
+    private sealed class PlaywrightResources : IAsyncDisposable
+    {
+        private readonly IPlaywright _playwright;
+        private readonly IBrowser _browser;
+        private readonly IBrowserContext _context;
+
+        public IPage Page { get; }
+
+        private PlaywrightResources(IPlaywright playwright, IBrowser browser, IBrowserContext context, IPage page)
+        {
+            _playwright = playwright;
+            _browser = browser;
+            _context = context;
+            Page = page;
+        }
+
+        public static async Task<PlaywrightResources> CreateAsync()
+        {
+            var playwright = await Playwright.CreateAsync();
+            var browser = await LaunchChromiumWithInstallFallback(playwright);
+            var context = await browser.NewContextAsync();
+            var page = await context.NewPageAsync();
+
+            return new PlaywrightResources(playwright, browser, context, page);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _context.DisposeAsync();
+            await _browser.DisposeAsync();
+            _playwright.Dispose();
+        }
+
+        private static async Task<IBrowser> LaunchChromiumWithInstallFallback(IPlaywright playwright)
+        {
+            try
+            {
+                return await LaunchChromium(playwright);
+            }
+            catch (PlaywrightException ex) when (ex.Message.Contains("Executable doesn't exist", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "Playwright Chromium is not installed for this test environment. Install Playwright browsers before running tests (for example using the generated Playwright install script in local and CI setup steps).",
+                    ex);
+            }
+        }
+
+        private static Task<IBrowser> LaunchChromium(IPlaywright playwright) =>
+            playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+    }
+}

--- a/Picea.Abies.Testing.Tests/VisualCliAppTests.cs
+++ b/Picea.Abies.Testing.Tests/VisualCliAppTests.cs
@@ -1,0 +1,100 @@
+using Picea.Abies.Cli;
+
+namespace Picea.Abies.Testing.Tests;
+
+public sealed class VisualCliAppTests
+{
+    [Test]
+    public async Task VisualAccept_WithSnapshot_CopiesActualToBaseline()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var artifactsDirectory = Path.Combine(root, "artifacts", "visual");
+            var baselinesDirectory = Path.Combine(root, "baselines", "visual");
+            Directory.CreateDirectory(artifactsDirectory);
+
+            var actualPath = Path.Combine(artifactsDirectory, "home-page.actual.png");
+            await File.WriteAllBytesAsync(actualPath, [1, 2, 3, 4]);
+
+            var output = new StringWriter();
+            var exitCode = await VisualCliApp.InvokeAsync([
+                "visual", "accept", "home-page.png",
+                "--artifacts", artifactsDirectory,
+                "--baselines", baselinesDirectory
+            ], output, output);
+
+            var baselinePath = Path.Combine(baselinesDirectory, "home-page.png");
+            await Assert.That(exitCode).IsEqualTo(0);
+            await Assert.That(File.Exists(baselinePath)).IsTrue();
+            await Assert.That(await File.ReadAllBytesAsync(baselinePath)).IsEquivalentTo(new byte[] { 1, 2, 3, 4 });
+        }
+        finally
+        {
+            DeleteIfExists(root);
+        }
+    }
+
+    [Test]
+    public async Task VisualAccept_AllAndReport_ProcessesPendingSnapshots()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var artifactsDirectory = Path.Combine(root, "artifacts", "visual");
+            var baselinesDirectory = Path.Combine(root, "baselines", "visual");
+            var reportDirectory = Path.Combine(root, "reports");
+            Directory.CreateDirectory(artifactsDirectory);
+
+            await File.WriteAllBytesAsync(Path.Combine(artifactsDirectory, "article-list.actual.png"), [9]);
+            await File.WriteAllBytesAsync(Path.Combine(artifactsDirectory, "article-list.diff.png"), [7]);
+
+            var output = new StringWriter();
+            var acceptAllExitCode = await VisualCliApp.InvokeAsync([
+                "visual", "accept", "--all",
+                "--artifacts", artifactsDirectory,
+                "--baselines", baselinesDirectory
+            ], output, output);
+
+            var statusExitCode = await VisualCliApp.InvokeAsync([
+                "visual", "status",
+                "--artifacts", artifactsDirectory,
+                "--baselines", baselinesDirectory
+            ], output, output);
+
+            var reportExitCode = await VisualCliApp.InvokeAsync([
+                "visual", "report",
+                "--output", reportDirectory,
+                "--artifacts", artifactsDirectory,
+                "--baselines", baselinesDirectory
+            ], output, output);
+
+            await Assert.That(acceptAllExitCode).IsEqualTo(0);
+            await Assert.That(statusExitCode).IsEqualTo(0);
+            await Assert.That(reportExitCode).IsEqualTo(0);
+            await Assert.That(File.Exists(Path.Combine(baselinesDirectory, "article-list.png"))).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(reportDirectory, "visual-report.md"))).IsTrue();
+        }
+        finally
+        {
+            DeleteIfExists(root);
+        }
+    }
+
+    private static string CreateTestRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "abies-visual-cli-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/Picea.Abies.sln
+++ b/Picea.Abies.sln
@@ -89,6 +89,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Testing", "Pice
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Testing.Tests", "Picea.Abies.Testing.Tests\Picea.Abies.Testing.Tests.csproj", "{052F811A-ECDC-4223-A488-2E0BBD0D2163}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Cli", "Picea.Abies.Cli\Picea.Abies.Cli.csproj", "{E31A97BB-14C9-46DB-915D-EF9522A0284F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -615,6 +617,18 @@ Global
 		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x64.Build.0 = Release|Any CPU
 		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x86.ActiveCfg = Release|Any CPU
 		{052F811A-ECDC-4223-A488-2E0BBD0D2163}.Release|x86.Build.0 = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|x64.Build.0 = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Debug|x86.Build.0 = Debug|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x64.ActiveCfg = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x64.Build.0 = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x86.ActiveCfg = Release|Any CPU
+		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -270,6 +270,76 @@ public class E2ETests : IAsyncLifetime
 }
 ```
 
+## Visual Regression Testing
+
+`Picea.Abies.Testing` ships a screenshot-based visual harness (`TestHarnessVisualExtensions`) plus an
+`abies` baseline-management CLI (`Picea.Abies.Cli`). It renders a model with Playwright, captures a PNG,
+and compares it against a stored baseline.
+
+On the **first run** the baseline is created automatically (`BaselineCreated == true`) and the comparison
+passes. On later runs the screenshot is diffed against that baseline; on mismatch, `.actual.png` and
+`.diff.png` artifacts are written next to the baseline.
+
+```csharp
+using Picea.Abies.Testing;
+
+var harness = TestHarness<MyProgram, MyModel, Unit>.Create(Unit.Value);
+
+var options = new VisualComparisonOptions(
+    ViewportWidth: 1280,
+    ViewportHeight: 720,
+    FullPage: true,
+    Tolerance: VisualComparisonTolerance.Strict); // every pixel channel must match exactly
+
+// Render + screenshot via Playwright, then compare (creates the baseline on first run):
+var result = await harness.CompareVisual(page, "baselines/home.png", options);
+await Assert.That(result.IsMatch).IsTrue();
+
+// Or assert directly (throws on mismatch in strict mode):
+await harness.AssertVisualMatch(page, "baselines/home.png", options);
+```
+
+Use `VisualComparisonTolerance` to allow controlled drift (`MaxPixelErrorCount`, `MaxPixelErrorPercentage`,
+`MaxMeanError`, `MaxAbsoluteError`, `PerChannelThreshold`). A `byte[]` overload of `CompareVisual` exists for
+comparing a screenshot you already captured.
+
+> Visual tests require Playwright browsers. Install them before running (the
+> [`visual-regression.yml`](../../.github/workflows/visual-regression.yml) workflow does this in CI); without
+> them the Playwright-backed tests fail with an "install Playwright browsers" message.
+
+### Managing baselines with the `abies` CLI
+
+When a change is intentional, promote the pending `*.actual.png` artifacts to baselines instead of editing
+images by hand:
+
+```bash
+# Accept one pending snapshot
+dotnet run --project Picea.Abies.Cli -- visual accept home-page.png \
+  --artifacts artifacts/visual --baselines baselines/visual
+
+# Accept every pending snapshot
+dotnet run --project Picea.Abies.Cli -- visual accept --all \
+  --artifacts artifacts/visual --baselines baselines/visual
+
+# List pending mismatches
+dotnet run --project Picea.Abies.Cli -- visual status \
+  --artifacts artifacts/visual --baselines baselines/visual
+
+# Write a markdown mismatch report (visual-report.md)
+dotnet run --project Picea.Abies.Cli -- visual report --output reports \
+  --artifacts artifacts/visual --baselines baselines/visual
+```
+
+The CLI is also packed as a .NET tool (`ToolCommandName` = `abies`), so once installed the commands are
+available as `abies visual accept|status|report`.
+
+> **Seeding baselines.** Screenshots are environment-sensitive (fonts, anti-aliasing), so baselines must be
+> generated on the same OS as CI. The `VisualRegression_*` tests in `Picea.Abies.Conduit.Tests` create a
+> baseline on first run and pass; the Visual Regression workflow uploads the generated PNGs as the
+> `visual-regression-*` artifact. Download that artifact, commit the baselines under
+> `Picea.Abies.Conduit.Tests/Snapshots/visual/`, and subsequent runs diff against them. Do **not** commit
+> baselines captured on a developer machine — they will mismatch the CI runner.
+
 ## Running Tests
 
 ```bash
@@ -278,6 +348,9 @@ dotnet test MyApp.Tests
 
 # E2E tests (requires app running)
 dotnet test MyApp.Testing.E2E
+
+# Visual regression tests (requires Playwright browsers installed)
+dotnet test Picea.Abies.Testing.Tests
 
 # All tests
 dotnet test
@@ -296,3 +369,4 @@ dotnet test
 - [Pure Functions](../concepts/pure-functions.md) — Why pure functions are testable
 - [Commands and Effects](../concepts/commands-effects.md) — Testing interpreters
 - [Conduit E2E Fixture Architecture](./conduit-e2e-fixture-architecture.md) — Real project fixture, seeding, and user-journey coverage patterns
+- [`visual-regression.yml`](../../.github/workflows/visual-regression.yml) — CI workflow for the visual harness


### PR DESCRIPTION
## What

Completes the visual regression harness reintroduction. PR #276 ("Reintroduce visual regression harness") was **trimmed to pass PR-size validation gates** (see its `fix(testing): trim visual PR payload to pass validation gates` commit), so it landed only `TestHarnessVisualExtensions.cs` + the workflow — the CLI, the harness tests, and the Conduit visual tests from #211 never made it back after the #224 history rewrite removed them.

This PR restores the missing pieces **and** wires real visual tests into the CI gate so the workflow actually exercises them.

## Why

After #276, the visual regression harness was effectively non-functional: the `abies` baseline CLI and the harness/Conduit tests were missing, and the `visual-regression.yml` gate could never run anything (it searched for `VisualRegression_*` tests that did not exist, and even if found, its VSTest-style filter selects zero tests under TUnit's Microsoft.Testing.Platform). This PR makes the harness usable again and gives the CI gate real tests to run, restoring screenshot-based regression coverage for Conduit.

## Changes

**Restored from #211 (`24be5d1`):**
- `Picea.Abies.Cli` — the `abies visual accept|status|report` baseline-management tool (+ added to the solution)
- `Picea.Abies.Testing.Tests/TestHarnessVisualTests.cs` and `VisualCliAppTests.cs`
- `Picea.Abies.Conduit.Testing.E2E/VisualSnapshotExampleTests.cs`

**New — wire the CI gate:**
- `Picea.Abies.Conduit.Tests/VisualRegressionTests.cs` — `VisualRegression_*` tests that drive the restored `CompareVisual` harness against deterministic static Conduit pages (Login/Register; routed via `Route.FromUrl` with `Commands.None`, no API fetch). Gated behind `ABIES_ENABLE_PIXEL_SNAPSHOTS=1`; skip cleanly when browsers/env are absent.

**Workflow fixes (`visual-regression.yml`) — three real bugs found while verifying with `act`:**
1. Detection used `rg`, which isn't guaranteed on all runners → `grep -rqs` (portable).
2. Pixel step used VSTest `--filter`/`--logger trx`, which selects zero tests under TUnit's Microsoft.Testing.Platform → `--treenode-filter` + `--report-trx` (matches `e2e.yml`).
3. Browser install was pwsh-only with a version-mismatched `npx` fallback → added the version-matched bundled Node CLI fallback.

**Docs:** documented the visual harness, the `abies` CLI, and the baseline-seeding flow in `docs/guides/testing.md`.

## Testing

- `Picea.Abies.Cli`, `Picea.Abies.Testing.Tests` build clean; restored unit tests pass.
- `Picea.Abies.Conduit.Tests` `VisualRegression_*` tests execute and pass locally (`total: 2, passed: 2`), create baselines, and a second run matches them (comparison verified).
- Ran the full `visual-regression.yml` locally via `act` and on this PR's CI: the **Pixel Snapshot Comparison** check passes — detection → `has_visual_tests=true`, MTP filter selects exactly the 2 tests, correct chromium installed, tests run green.

## Note on baselines

Baselines are intentionally **not committed** — screenshots are environment-sensitive, so committing developer-machine PNGs would mismatch the CI runner. The tests create-on-first-run (pass) and the workflow uploads the generated PNGs as the `visual-regression-*` artifact; a maintainer downloads and commits those once to enable diffing. See `docs/guides/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)