### PR TITLE
chore(release): Bump version.json to 2.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.0"
+    "version": "2.1"
 }


### PR DESCRIPTION
## What

Bumps the declared base version in `version.json` from `2.0` to `2.1`.

## Why

The 2.1.0 stable NuGet packages were published from the `v2.1.0` tag, where the Release workflow forces the version (`nbgv set-version` + `/p:Version=2.1.0`). But `version.json` still declared `2.0`, so non-tag CI dev builds compute `2.0.x` (Nerdbank.GitVersioning `SimpleVersion`). This bump aligns dev builds with the released line so they compute `2.1.x`.

This does not affect any published package — released versions are determined by the tag, not `version.json`.

## Testing

- No code change; `version.json` only. CI builds will confirm versioning resolves to `2.1.x` on this branch.