### PR TITLE
test(templates): Cover debugger default-on for abies-browser-empty

### DIFF
--- a/Picea.Abies.Templates.Testing.E2E/BrowserEmptyTemplateTests.cs
+++ b/Picea.Abies.Templates.Testing.E2E/BrowserEmptyTemplateTests.cs
@@ -93,6 +93,25 @@ public class BrowserEmptyTemplateTests : IAsyncDisposable
     }
 
     [Test]
+    public async Task InitialLoad_DebuggerEnabledByDefault_MountsAndTogglesPanel()
+    {
+        await _page.GotoAsync("/");
+
+        // The empty template enables the Time Travel Debugger by default (Debug builds),
+        // so its shell must mount and toggle its panel — same default as abies-browser.
+        var shell = _page.Locator("[data-abies-debugger-shell='1']");
+        var panel = _page.Locator("[data-abies-debugger-panel='1']");
+
+        await Assertions.Expect(shell).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+        await shell.ClickAsync();
+        await Assertions.Expect(panel).ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+        await shell.ClickAsync();
+        await Assertions.Expect(panel).Not.ToBeVisibleAsync(new() { Timeout = 10_000 });
+    }
+
+    [Test]
     public async Task ReleasePublish_Succeeds()
     {
         var (exitCode, stdOut, stdErr) = await DotNetCli.RunAsync(


### PR DESCRIPTION
## What

Adds an E2E test asserting the Time Travel Debugger mounts (and its panel toggles) by default in a project scaffolded from `dotnet new abies-browser-empty`.

## Why

All three templates enable the debugger by default in Debug builds, and this is verified end-to-end for `abies-browser` (`BrowserTemplateTests.InitialLoad_DebuggerBadgeClick_TogglesDebuggerPanel`) and `abies-server`. The `abies-browser-empty` E2E suite, however, only checked the welcome content / `abies.js` / release publish — it never asserted the debugger UI actually mounts at runtime. Since the empty template is what many "blank slate" `new abies...` projects start from, this closes the one remaining coverage gap so a regression in the empty template's debugger default would be caught.

## Changes

- `Picea.Abies.Templates.Testing.E2E/BrowserEmptyTemplateTests.cs`: new `InitialLoad_DebuggerEnabledByDefault_MountsAndTogglesPanel` test (reuses the existing `BrowserEmptyTemplateFixture`).

## Testing

- E2E project compiles clean.
- The new test runs in the templates E2E CI job (scaffolds the template, builds WASM, serves it, and drives the debugger shell/panel via Playwright).