### PR TITLE
feat(native): Add platform-neutral native control vocabulary and patch interpreter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,6 +124,8 @@ jobs:
       run: dotnet test --project Picea.Abies.Conduit.Api.Tests/Picea.Abies.Conduit.Api.Tests.csproj --no-build --verbosity normal
     - name: Test Picea.Abies.Analyzers.Tests
       run: dotnet test --project Picea.Abies.Analyzers.Tests/Picea.Abies.Analyzers.Tests.csproj --no-build --verbosity normal
+    - name: Test Picea.Abies.Native.Tests
+      run: dotnet test --project Picea.Abies.Native.Tests/Picea.Abies.Native.Tests.csproj --no-build --verbosity normal
     - name: Test Picea.Abies.Templates.Testing (build-smoke only)
       run: dotnet test --project Picea.Abies.Templates.Testing/Picea.Abies.Templates.Testing.csproj --no-build --verbosity normal -- --treenode-filter "/*/*/*/*[Category!=E2E]"
 

--- a/Picea.Abies.Native.Tests/FakeBackend.cs
+++ b/Picea.Abies.Native.Tests/FakeBackend.cs
@@ -1,0 +1,97 @@
+// =============================================================================
+// Fake Backend — Headless Recording Implementation of INativeBackend
+// =============================================================================
+// A control is a plain object with a property bag and child list. The backend
+// records every operation so tests can assert both the final tree shape and
+// the operations that produced it (e.g., "reorder moved controls instead of
+// recreating them").
+// =============================================================================
+
+using Picea.Abies.Native.Rendering;
+
+namespace Picea.Abies.Native.Tests;
+
+public sealed class FakeControl(string tag, string id)
+{
+    public string Tag { get; } = tag;
+    public string Id { get; } = id;
+    public Dictionary<string, string?> Props { get; } = [];
+    public List<FakeControl> Children { get; } = [];
+    public HashSet<string> AttachedEvents { get; } = [];
+}
+
+public sealed class FakeBackend : INativeBackend<FakeControl>
+{
+    public FakeControl? Root { get; private set; }
+    public List<FakeControl> AllCreated { get; } = [];
+    public List<string> Log { get; } = [];
+
+    public FakeControl CreateControl(string tag, string elementId)
+    {
+        var control = new FakeControl(tag, elementId);
+        AllCreated.Add(control);
+        Log.Add($"create {tag}#{elementId}");
+        return control;
+    }
+
+    public void SetProperty(FakeControl control, string tag, string name, string? value)
+    {
+        if (value is null)
+            control.Props.Remove(name);
+        else
+            control.Props[name] = value;
+        Log.Add($"set {tag}#{control.Id}.{name}={value ?? "<null>"}");
+    }
+
+    public void AppendChild(FakeControl parent, string parentTag, FakeControl child)
+    {
+        parent.Children.Add(child);
+        Log.Add($"append {child.Id} -> {parent.Id}");
+    }
+
+    public void ReplaceChild(FakeControl parent, string parentTag, FakeControl oldChild, FakeControl newChild)
+    {
+        parent.Children[parent.Children.IndexOf(oldChild)] = newChild;
+        Log.Add($"replace {oldChild.Id} with {newChild.Id} in {parent.Id}");
+    }
+
+    public void RemoveChild(FakeControl parent, string parentTag, FakeControl child)
+    {
+        parent.Children.Remove(child);
+        Log.Add($"remove {child.Id} from {parent.Id}");
+    }
+
+    public void MoveChild(FakeControl parent, string parentTag, FakeControl child, FakeControl? before)
+    {
+        parent.Children.Remove(child);
+        if (before is null)
+            parent.Children.Add(child);
+        else
+            parent.Children.Insert(parent.Children.IndexOf(before), child);
+        Log.Add($"move {child.Id} before {before?.Id ?? "<end>"} in {parent.Id}");
+    }
+
+    public void ClearChildren(FakeControl parent, string parentTag)
+    {
+        parent.Children.Clear();
+        Log.Add($"clear {parent.Id}");
+    }
+
+    public void SetRoot(FakeControl root)
+    {
+        Root = root;
+        Log.Add($"root {root.Id}");
+    }
+
+    public void AttachEvent(FakeControl control, string tag, string eventName, string elementId, INativeEventSink sink)
+    {
+        control.AttachedEvents.Add(eventName);
+        Log.Add($"attach {eventName} on {elementId}");
+    }
+
+    public void DetachEvent(FakeControl control, string tag, string eventName)
+    {
+        control.AttachedEvents.Remove(eventName);
+        Log.Add($"detach {eventName} on {control.Id}");
+    }
+}

--- a/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
+++ b/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
@@ -1,0 +1,334 @@
+// =============================================================================
+// Patch Interpreter Tests
+// =============================================================================
+// Drives the real Operations.Diff over native-vocabulary trees and asserts
+// the FakeBackend ends up with the right control tree — plus direct patch
+// cases for paths the diff reaches rarely (SetChildrenHtml, head patches)
+// and the Text/Raw tripwires.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Picea.Abies.Native.Rendering;
+using Attribute = Picea.Abies.DOM.Attribute;
+
+namespace Picea.Abies.Native.Tests;
+
+public record Ping : Message;
+public record Pong : Message;
+
+public class PatchInterpreterTests
+{
+    private static (PatchInterpreter<FakeControl> Interpreter, FakeBackend Backend) Create()
+    {
+        var backend = new FakeBackend();
+        return (new PatchInterpreter<FakeControl>(backend), backend);
+    }
+
+    private static Element Item(string id, string key, string text) =>
+        new(id, "TextBlock", [new Attribute($"{id}-k", "key", key), new Attribute($"{id}-t", "Text", text)]);
+
+    // =========================================================================
+    // Initial render
+    // =========================================================================
+
+    [Test]
+    public async Task InitialRender_BuildsControlTree()
+    {
+        var (interpreter, backend) = Create();
+        var view = new Element("root", "StackPanel",
+            [new Attribute("a1", "Spacing", "12"), new Attribute("a2", "key", "ignored")],
+            new Element("t1", "TextBlock", [new Attribute("a3", "Text", "0")]),
+            new Element("b1", "Button",
+                [new Attribute("a4", "Content", "+"), new Handler("Click", "c1", new Ping(), "h1")]));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        var root = backend.Root!;
+        await Assert.That(root.Tag).IsEqualTo("StackPanel");
+        await Assert.That(root.Props["Spacing"]).IsEqualTo("12");
+        await Assert.That(root.Props.ContainsKey("key")).IsFalse();
+        await Assert.That(root.Children).Count().IsEqualTo(2);
+        await Assert.That(root.Children[0].Props["Text"]).IsEqualTo("0");
+        await Assert.That(root.Children[1].Props["Content"]).IsEqualTo("+");
+        await Assert.That(root.Children[1].AttachedEvents.Contains("Click")).IsTrue();
+        await Assert.That(interpreter.ControlCount).IsEqualTo(3);
+    }
+
+    // =========================================================================
+    // Attribute updates
+    // =========================================================================
+
+    [Test]
+    public async Task AttributeUpdate_SetsNewValue()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("t1", "TextBlock", [new Attribute("a1", "Text", "0")]);
+        var @new = new Element("t1", "TextBlock", [new Attribute("a1", "Text", "1")]);
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Root!.Props["Text"]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task AttributeRemove_ResetsProperty()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("t1", "TextBlock",
+            [new Attribute("a1", "Text", "x"), new Attribute("a2", "FontSize", "24")]);
+        var @new = new Element("t1", "TextBlock", [new Attribute("a1", "Text", "x")]);
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Root!.Props.ContainsKey("FontSize")).IsFalse();
+        await Assert.That(backend.Root!.Props["Text"]).IsEqualTo("x");
+    }
+
+    // =========================================================================
+    // Handler lifecycle
+    // =========================================================================
+
+    [Test]
+    public async Task StaticHandler_DispatchesCommand()
+    {
+        var (interpreter, backend) = Create();
+        var view = new Element("b1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]);
+        interpreter.Apply(Operations.Diff(null, view));
+
+        Message? dispatched = null;
+        interpreter.Dispatch = m => { dispatched = m; return ValueTask.CompletedTask; };
+        interpreter.OnNativeEvent("b1", "Click", null);
+
+        await Assert.That(dispatched).IsTypeOf<Ping>();
+    }
+
+    [Test]
+    public async Task UpdateHandler_SwapsMessageWithoutReattaching()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("b1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]);
+        var @new = new Element("b1", "Button", [new Handler("Click", "c2", new Pong(), "h1")]);
+
+        interpreter.Apply(Operations.Diff(null, old));
+        var attachCountAfterFirstRender = backend.Log.Count(l => l.StartsWith("attach"));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        Message? dispatched = null;
+        interpreter.Dispatch = m => { dispatched = m; return ValueTask.CompletedTask; };
+        interpreter.OnNativeEvent("b1", "Click", null);
+
+        await Assert.That(dispatched).IsTypeOf<Pong>();
+        await Assert.That(backend.Log.Count(l => l.StartsWith("attach"))).IsEqualTo(attachCountAfterFirstRender);
+    }
+
+    [Test]
+    public async Task DataHandler_ReceivesNativeEventData()
+    {
+        var (interpreter, _) = Create();
+        var view = new Element("tb1", "TextBox",
+            [new Handler("TextChanged", "c1", null, "h1", o => new Echo(((TextChangedData?)o)!.Text))]);
+        interpreter.Apply(Operations.Diff(null, view));
+
+        Message? dispatched = null;
+        interpreter.Dispatch = m => { dispatched = m; return ValueTask.CompletedTask; };
+        interpreter.OnNativeEvent("tb1", "TextChanged", new TextChangedData("hello"));
+
+        await Assert.That(dispatched).IsTypeOf<Echo>();
+        await Assert.That(((Echo)dispatched!).Text).IsEqualTo("hello");
+    }
+
+    public record Echo(string Text) : Message;
+
+    // =========================================================================
+    // Children: keyed reorder, removal
+    // =========================================================================
+
+    [Test]
+    public async Task KeyedReorder_MovesExistingControls()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [],
+            Item("ia", "a", "A"), Item("ib", "b", "B"), Item("ic", "c", "C"));
+        var @new = new Element("p", "StackPanel", [],
+            Item("ic", "c", "C"), Item("ia", "a", "A"), Item("ib", "b", "B"));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        var createdAfterFirstRender = backend.AllCreated.Count;
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        var order = backend.Root!.Children.Select(c => c.Id).ToArray();
+        await Assert.That(order).IsEquivalentTo(new[] { "ic", "ia", "ib" });
+        await Assert.That(backend.AllCreated.Count).IsEqualTo(createdAfterFirstRender);
+    }
+
+    [Test]
+    public async Task RemovingAllChildren_EmptiesParentAndTracking()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [],
+            Item("ia", "a", "A"), Item("ib", "b", "B"), Item("ic", "c", "C"));
+        var @new = new Element("p", "StackPanel", []);
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Root!.Children).IsEmpty();
+        await Assert.That(interpreter.ControlCount).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// Backends key their event bookkeeping by control instance, so dropping a
+    /// subtree must detach its handlers — otherwise the backend holds the dead
+    /// control (and its closures) forever.
+    /// </summary>
+    [Test]
+    public async Task RemovedSubtree_DetachesNativeEvents()
+    {
+        var (interpreter, backend) = Create();
+        var button = new Element("b1", "Button",
+            [new Attribute("a1", "key", "b"), new Handler("Click", "c1", new Ping(), "h1")]);
+        var old = new Element("p", "StackPanel", [], button);
+        var @new = new Element("p", "StackPanel", []);
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Log.Count(l => l.StartsWith("attach")))
+            .IsEqualTo(backend.Log.Count(l => l.StartsWith("detach")));
+        await Assert.That(backend.AllCreated.Single(c => c.Id == "b1").AttachedEvents).IsEmpty();
+    }
+
+    /// <summary>Replacing a subtree must detach the handlers of the old one.</summary>
+    [Test]
+    public async Task ReplacedSubtree_DetachesOldControlEvents()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [],
+            new Element("x1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]));
+        var @new = new Element("p", "StackPanel", [],
+            new Element("x1", "TextBlock", [new Attribute("a1", "Text", "done")]));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Log.Count(l => l.StartsWith("detach"))).IsEqualTo(1);
+    }
+
+    /// <summary>A new root drops the previous tree, detaching all of its events.</summary>
+    [Test]
+    public async Task NewRoot_DetachesPreviousTreeEvents()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [],
+            new Element("b1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply([new AddRoot(new Element("g", "Grid", []))]);
+
+        await Assert.That(backend.Log.Count(l => l.StartsWith("detach"))).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// AddChild appends, so a mid-list insertion relies on the diff emitting a
+    /// MoveChild to restore order. This pins that end-to-end behaviour.
+    /// </summary>
+    [Test]
+    public async Task InsertingChildInMiddle_PreservesOrder()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [], Item("ia", "a", "A"), Item("ic", "c", "C"));
+        var @new = new Element("p", "StackPanel", [],
+            Item("ia", "a", "A"), Item("ib", "b", "B"), Item("ic", "c", "C"));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        var order = backend.Root!.Children.Select(c => c.Id).ToArray();
+        await Assert.That(order).IsEquivalentTo(new[] { "ia", "ib", "ic" });
+    }
+
+    [Test]
+    public async Task TagChange_ReplacesControlInPlace()
+    {
+        var (interpreter, backend) = Create();
+        var old = new Element("p", "StackPanel", [],
+            new Element("x1", "TextBlock", [new Attribute("a1", "Text", "read")]));
+        var @new = new Element("p", "StackPanel", [],
+            new Element("x2", "TextBox", [new Attribute("a2", "Text", "edit")]));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        await Assert.That(backend.Root!.Children).Count().IsEqualTo(1);
+        await Assert.That(backend.Root!.Children[0].Tag).IsEqualTo("TextBox");
+        await Assert.That(backend.Root!.Children[0].Props["Text"]).IsEqualTo("edit");
+        await Assert.That(interpreter.ControlCount).IsEqualTo(2);
+    }
+
+    // =========================================================================
+    // Direct patch paths
+    // =========================================================================
+
+    [Test]
+    public async Task SetChildrenHtml_MaterializesNodeChildren()
+    {
+        var (interpreter, backend) = Create();
+        var parent = new Element("p", "StackPanel", []);
+        interpreter.Apply(Operations.Diff(null, parent));
+
+        interpreter.Apply([new SetChildrenHtml(parent,
+            [Item("ia", "a", "A"), Item("ib", "b", "B")])]);
+
+        var texts = backend.Root!.Children.Select(c => c.Props["Text"]!).ToArray();
+        await Assert.That(texts).IsEquivalentTo(new[] { "A", "B" });
+    }
+
+    [Test]
+    public async Task AppendChildrenHtml_AppendsAfterExisting()
+    {
+        var (interpreter, backend) = Create();
+        var parent = new Element("p", "StackPanel", [], Item("ia", "a", "A"));
+        interpreter.Apply(Operations.Diff(null, parent));
+
+        interpreter.Apply([new AppendChildrenHtml(parent, [Item("ib", "b", "B")])]);
+
+        var order = backend.Root!.Children.Select(c => c.Id).ToArray();
+        await Assert.That(order).IsEquivalentTo(new[] { "ia", "ib" });
+    }
+
+    [Test]
+    public async Task TextPatch_Throws()
+    {
+        var (interpreter, _) = Create();
+        var parent = new Element("p", "StackPanel", []);
+        interpreter.Apply(Operations.Diff(null, parent));
+
+        await Assert.That(() => interpreter.Apply([new AddText(parent, new Text("t", "boom"))]))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task TextChildInBuiltSubtree_Throws()
+    {
+        var (interpreter, _) = Create();
+        var view = new Element("p", "StackPanel", [], new Text("t", "boom"));
+
+        await Assert.That(() => interpreter.Apply(Operations.Diff(null, view)))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task HeadPatches_AreIgnored()
+    {
+        var (interpreter, backend) = Create();
+        var parent = new Element("p", "StackPanel", []);
+        interpreter.Apply(Operations.Diff(null, parent));
+        var logCount = backend.Log.Count;
+
+        interpreter.Apply([new RemoveHeadElement("some-key")]);
+
+        await Assert.That(backend.Log.Count).IsEqualTo(logCount);
+    }
+}

--- a/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
+++ b/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
@@ -93,7 +93,7 @@ public class PatchInterpreterTests
     [Test]
     public async Task StaticHandler_DispatchesCommand()
     {
-        var (interpreter, backend) = Create();
+        var (interpreter, _) = Create();
         var view = new Element("b1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]);
         interpreter.Apply(Operations.Diff(null, view));
 

--- a/Picea.Abies.Native.Tests/Picea.Abies.Native.Tests.csproj
+++ b/Picea.Abies.Native.Tests/Picea.Abies.Native.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Praefixum</InterceptorsNamespaces>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Praefixum" Version="2.0.1" />
+    <PackageReference Include="TUnit" Version="1.19.57" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
+    <ProjectReference Include="..\Picea.Abies.Native\Picea.Abies.Native.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Picea.Abies.Native.Tests/RuntimeIntegrationTests.cs
+++ b/Picea.Abies.Native.Tests/RuntimeIntegrationTests.cs
@@ -1,0 +1,87 @@
+// =============================================================================
+// Runtime Integration Test — Full MVU Loop, Headless
+// =============================================================================
+// Proves the whole native pipeline with no UI framework at all:
+// Program (native-vocabulary View) → Runtime.Start → Diff → PatchInterpreter
+// → FakeBackend, and back: native event → handler → Runtime.Dispatch →
+// re-render → patched fake tree.
+//
+// The View uses the real Elements/Properties/Events factories, which also
+// exercises Praefixum id interception in a consumer assembly.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Picea.Abies.Native.Rendering;
+using Picea.Abies.Subscriptions;
+using static Picea.Abies.Native.Elements;
+using static Picea.Abies.Native.Events;
+using static Picea.Abies.Native.Properties;
+
+namespace Picea.Abies.Native.Tests;
+
+public record CountModel(int Count);
+public record Increment : Message;
+
+public sealed class NativeTestProgram : Program<CountModel, Unit>
+{
+    public static (CountModel, Command) Initialize(Unit _) => (new CountModel(0), Commands.None);
+
+    public static (CountModel, Command) Transition(CountModel model, Message message) =>
+        message switch
+        {
+            Increment => (model with { Count = model.Count + 1 }, Commands.None),
+            _ => (model, Commands.None)
+        };
+
+    public static Result<Message[], Message> Decide(CountModel _, Message command) =>
+        Result<Message[], Message>.Ok([command]);
+
+    public static bool IsTerminal(CountModel _) => false;
+
+    public static Document View(CountModel model) =>
+        new("Native Test",
+            StackPanel([Spacing(8)],
+            [
+                TextBlock([FontSize(24)], model.Count.ToString()),
+                Button([OnClick(new Increment())], "+"),
+            ]));
+
+    public static Subscription Subscriptions(CountModel _) => new Subscription.None();
+}
+
+public class RuntimeIntegrationTests
+{
+    private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>
+        ValueTask.FromResult(Result<Message[], PipelineError>.Ok([]));
+
+    [Test]
+    public async Task FullLoop_RenderDispatchRerender()
+    {
+        var backend = new FakeBackend();
+        var interpreter = new PatchInterpreter<FakeControl>(backend);
+        string? title = null;
+
+        using var runtime = await Runtime<NativeTestProgram, CountModel, Unit>.Start(
+            interpreter.Apply, NoOpInterpreter, Unit.Value,
+            titleChanged: t => title = t);
+
+        // Initial render reached the fake backend.
+        var root = backend.Root!;
+        await Assert.That(root.Tag).IsEqualTo("StackPanel");
+        await Assert.That(root.Children[0].Props["Text"]).IsEqualTo("0");
+        await Assert.That(title).IsEqualTo("Native Test");
+
+        // A native click resolves the handler and produces the message...
+        Message? clicked = null;
+        interpreter.Dispatch = m => { clicked = m; return ValueTask.CompletedTask; };
+        var button = root.Children[1];
+        await Assert.That(button.AttachedEvents.Contains("Click")).IsTrue();
+        interpreter.OnNativeEvent(button.Id, "Click", null);
+        await Assert.That(clicked).IsTypeOf<Increment>();
+
+        // ...and dispatching it re-renders through the same pipeline.
+        var result = await runtime.Dispatch(clicked!);
+        await Assert.That(result.IsOk).IsTrue();
+        await Assert.That(root.Children[0].Props["Text"]).IsEqualTo("1");
+    }
+}

--- a/Picea.Abies.Native/Elements.cs
+++ b/Picea.Abies.Native/Elements.cs
@@ -1,0 +1,91 @@
+// =============================================================================
+// Native Control Elements
+// =============================================================================
+// Factory functions describing native controls as Abies virtual DOM elements.
+// Tags are WinUI control names ("StackPanel", "TextBlock", ...); the diff and
+// patch machinery is vocabulary-agnostic and reused unchanged.
+//
+// Rules that keep the HTML fallbacks out of native trees:
+//   1. Only Element nodes — text is always a property attribute (Text/Content),
+//      never a Text child node. This prevents the diff's Text/RawHtml
+//      ReplaceRaw fallback from ever firing.
+//   2. Never name a tag Input, Source, Track, Base, or Link (case-insensitive):
+//      HtmlSpec.VoidElements would silently skip child diffing for them.
+//
+// Like the HTML DSL, a user-supplied Properties.Id attribute overrides the
+// compile-time Praefixum id — required for elements created in loops.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Praefixum;
+
+namespace Picea.Abies.Native;
+
+/// <summary>
+/// Factory functions for native control elements.
+/// </summary>
+public static class Elements
+{
+    /// <summary>
+    /// Core element factory. If the attributes contain an "id" attribute
+    /// (from <see cref="Properties.Id"/>), its value becomes the element id
+    /// and the attribute is removed; otherwise the Praefixum call-site id is
+    /// used.
+    /// </summary>
+    public static Element element(string tag, DOM.Attribute[] attributes, Node[] children, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+    {
+        var explicitId = Array.Find(attributes, a => a.Name == "id");
+        var elementId = explicitId?.Value ?? id!;
+        var filteredAttributes = explicitId != null
+            ? Array.FindAll(attributes, a => a.Name != "id")
+            : attributes;
+        return new(elementId, tag, filteredAttributes, children);
+    }
+
+    // =========================================================================
+    // Panels
+    // =========================================================================
+
+    public static Node StackPanel(DOM.Attribute[] attributes, Node[] children, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("StackPanel", attributes, children, id);
+
+    public static Node Grid(DOM.Attribute[] attributes, Node[] children, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Grid", attributes, children, id);
+
+    public static Node Border(DOM.Attribute[] attributes, Node child, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Border", attributes, [child], id);
+
+    public static Node ScrollViewer(DOM.Attribute[] attributes, Node child, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ScrollViewer", attributes, [child], id);
+
+    // =========================================================================
+    // Text & media
+    // =========================================================================
+
+    /// <summary>Read-only text. The text is carried as a "Text" attribute.</summary>
+    public static Node TextBlock(DOM.Attribute[] attributes, string text, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("TextBlock", [.. attributes, new DOM.Attribute(id ?? string.Empty, "Text", text)], [], id);
+
+    public static Node Image(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Image", attributes, [], id);
+
+    // =========================================================================
+    // Input controls
+    // =========================================================================
+
+    /// <summary>Button with string content, carried as a "Content" attribute.</summary>
+    public static Node Button(DOM.Attribute[] attributes, string content, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Button", [.. attributes, new DOM.Attribute(id ?? string.Empty, "Content", content)], [], id);
+
+    /// <summary>Editable text box. Set text via Properties.Text, listen via Events.OnTextChanged.</summary>
+    public static Node TextBox(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("TextBox", attributes, [], id);
+
+    /// <summary>CheckBox with string content, carried as a "Content" attribute.</summary>
+    public static Node CheckBox(DOM.Attribute[] attributes, string content, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("CheckBox", [.. attributes, new DOM.Attribute(id ?? string.Empty, "Content", content)], [], id);
+
+    /// <summary>Range slider. Set via Properties.Minimum/Maximum/Value, listen via Events.OnValueChanged.</summary>
+    public static Node Slider(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Slider", attributes, [], id);
+}

--- a/Picea.Abies.Native/EventData.cs
+++ b/Picea.Abies.Native/EventData.cs
@@ -1,0 +1,24 @@
+// =============================================================================
+// Native Event Data
+// =============================================================================
+// Event payload records for native control events. Unlike the browser event
+// data in Picea.Abies.Html (which is deserialized from JSON produced by
+// extractEventData in abies.js), these records are constructed directly by
+// the native backend from real event args — no serialization is involved,
+// and Handler.Deserializer stays null.
+// =============================================================================
+
+namespace Picea.Abies.Native;
+
+/// <summary>Payload for text-input changes (TextBox.TextChanged).</summary>
+/// <param name="Text">The current text of the control.</param>
+public sealed record TextChangedData(string Text);
+
+/// <summary>Payload for two-state toggles (CheckBox Checked/Unchecked).</summary>
+/// <param name="IsChecked">The new checked state.</param>
+public sealed record ToggledData(bool IsChecked);
+
+/// <summary>Payload for range-value changes (Slider.ValueChanged).</summary>
+/// <param name="NewValue">The new value.</param>
+/// <param name="OldValue">The previous value.</param>
+public sealed record ValueChangedData(double NewValue, double OldValue);

--- a/Picea.Abies.Native/Events.cs
+++ b/Picea.Abies.Native/Events.cs
@@ -1,0 +1,71 @@
+// =============================================================================
+// Native Event Handlers
+// =============================================================================
+// Factory functions for native control event handlers. Each returns a
+// Handler carrying the native event name (e.g., "Click", "TextChanged") and
+// either a static message or a WithData factory over a native event-data
+// record from EventData.cs.
+//
+// Unlike the HTML DSL, no JSON deserializer is registered: the native
+// renderer constructs the event-data record directly from real event args
+// and invokes Handler.WithData itself (it never goes through
+// HandlerRegistry.CreateMessage).
+//
+// Command IDs use the "nh{n}" prefix to stay disjoint from the HTML DSL's
+// "h{n}" ids when both vocabularies are loaded in one process.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Praefixum;
+
+namespace Picea.Abies.Native;
+
+/// <summary>
+/// Factory functions for native control event handler attributes.
+/// </summary>
+public static class Events
+{
+    private static long _commandIdCounter;
+
+    private static string NextCommandId()
+    {
+        var id = Interlocked.Increment(ref _commandIdCounter);
+        return string.Create(null, stackalloc char[24], $"nh{id}");
+    }
+
+    /// <summary>
+    /// Creates a handler that dispatches a static message when the named
+    /// native event fires.
+    /// </summary>
+    /// <param name="name">The native event name (e.g., "Click").</param>
+    /// <param name="command">The message to dispatch.</param>
+    /// <param name="id">Compile-time unique identifier for this handler.</param>
+    public static Handler On(string name, Message command, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => new(name, NextCommandId(), command, id ?? string.Empty);
+
+    /// <summary>
+    /// Creates a handler that produces a message from native event data.
+    /// </summary>
+    /// <typeparam name="T">The event data record type (e.g., <see cref="TextChangedData"/>).</typeparam>
+    /// <param name="name">The native event name (e.g., "TextChanged").</param>
+    /// <param name="factory">Creates a message from the event data.</param>
+    /// <param name="id">Compile-time unique identifier for this handler.</param>
+    public static Handler On<T>(string name, Func<T?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => new(name, NextCommandId(), null, id ?? string.Empty, o => factory((T?)o));
+
+    /// <summary>Button (and other ButtonBase) click.</summary>
+    public static Handler OnClick(Message command, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("Click", command, id);
+
+    /// <summary>TextBox text change, carrying the current text.</summary>
+    public static Handler OnTextChanged(Func<TextChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("TextChanged", factory, id);
+
+    /// <summary>CheckBox checked/unchecked, unified into one toggle event.</summary>
+    public static Handler OnToggled(Func<ToggledData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("Toggled", factory, id);
+
+    /// <summary>Slider value change.</summary>
+    public static Handler OnValueChanged(Func<ValueChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("ValueChanged", factory, id);
+}

--- a/Picea.Abies.Native/Picea.Abies.Native.csproj
+++ b/Picea.Abies.Native/Picea.Abies.Native.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Praefixum</InterceptorsNamespaces>
+  </PropertyGroup>
+
+  <!-- NuGet package metadata -->
+  <PropertyGroup>
+    <PackageId>Picea.Abies.Native</PackageId>
+    <Title>Picea.Abies.Native</Title>
+    <Description>Native control vocabulary and platform-neutral patch interpreter for the Abies MVU framework. Describes native UI (StackPanel, TextBlock, Button, ...) as Abies virtual DOM elements and interprets the resulting patch stream against any INativeBackend implementation. No UI framework dependencies.</Description>
+    <Authors>Maurice Peters</Authors>
+    <PackageTags>picea;abies;native;winui;mvu;elm;functional;automaton</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/picea/abies</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/picea/abies</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies\Picea.Abies.csproj" />
+    <PackageReference Include="Praefixum" Version="2.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -1,0 +1,182 @@
+// =============================================================================
+// Native Control Properties
+// =============================================================================
+// Typed property helpers that encode native control properties as
+// string-valued virtual DOM attributes. The diff compares attribute values
+// as strings; the backend parses them into native types (enums, doubles,
+// Thickness, Brush) when applying patches.
+//
+// All numeric formatting uses InvariantCulture so diffing and parsing are
+// locale-independent.
+//
+// Two attribute names are special and never reach the backend as properties:
+//   - "id"  — overrides the element's virtual DOM id (see Elements.element)
+//   - "key" — feeds the diff's keyed child reconciliation
+// =============================================================================
+
+using System.Globalization;
+using Praefixum;
+
+namespace Picea.Abies.Native;
+
+/// <summary>Layout orientation for stack-like panels.</summary>
+public enum Orientation { Vertical, Horizontal }
+
+/// <summary>
+/// Platform-neutral alignment. The backend maps Start/End onto
+/// Left/Right (horizontal) or Top/Bottom (vertical).
+/// </summary>
+public enum Alignment { Start, Center, End, Stretch }
+
+/// <summary>Font weight for text-bearing controls.</summary>
+public enum FontWeight { Normal, SemiBold, Bold }
+
+/// <summary>
+/// Factory functions for native control property attributes.
+/// </summary>
+public static class Properties
+{
+    private static string Num(double v) => v.ToString(CultureInfo.InvariantCulture);
+
+    private static DOM.Attribute Attr(string name, string value, string? id)
+        => new(id ?? string.Empty, name, value);
+
+    // =========================================================================
+    // Identity & keying
+    // =========================================================================
+
+    /// <summary>
+    /// Overrides the element's virtual DOM id. Required for elements created
+    /// in loops, where the compile-time call-site id is shared by all
+    /// iterations. Consumed by the element factory; never sent to the backend.
+    /// </summary>
+    public static DOM.Attribute Id(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("id", value, id);
+
+    /// <summary>
+    /// Reconciliation key for keyed child diffing (minimal moves via LIS).
+    /// Never sent to the backend.
+    /// </summary>
+    public static DOM.Attribute Key(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("key", value, id);
+
+    // =========================================================================
+    // Layout
+    // =========================================================================
+
+    public static DOM.Attribute Orientation(Orientation value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Orientation", value.ToString(), id);
+
+    public static DOM.Attribute Spacing(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Spacing", Num(value), id);
+
+    public static DOM.Attribute Padding(double uniform, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Padding", Num(uniform), id);
+
+    public static DOM.Attribute Padding(double left, double top, double right, double bottom, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Padding", $"{Num(left)},{Num(top)},{Num(right)},{Num(bottom)}", id);
+
+    public static DOM.Attribute Margin(double uniform, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Margin", Num(uniform), id);
+
+    public static DOM.Attribute Margin(double left, double top, double right, double bottom, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Margin", $"{Num(left)},{Num(top)},{Num(right)},{Num(bottom)}", id);
+
+    public static DOM.Attribute Width(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Width", Num(value), id);
+
+    public static DOM.Attribute Height(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Height", Num(value), id);
+
+    public static DOM.Attribute HorizontalAlignment(Alignment value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("HorizontalAlignment", value.ToString(), id);
+
+    public static DOM.Attribute VerticalAlignment(Alignment value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("VerticalAlignment", value.ToString(), id);
+
+    // =========================================================================
+    // Grid layout
+    // =========================================================================
+
+    /// <summary>Comma-separated row sizes: "Auto", "*", "2*", or a number.</summary>
+    public static DOM.Attribute RowDefinitions(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("RowDefinitions", value, id);
+
+    /// <summary>Comma-separated column sizes: "Auto", "*", "2*", or a number.</summary>
+    public static DOM.Attribute ColumnDefinitions(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("ColumnDefinitions", value, id);
+
+    /// <summary>Grid.Row attached property.</summary>
+    public static DOM.Attribute GridRow(int value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Grid.Row", value.ToString(CultureInfo.InvariantCulture), id);
+
+    /// <summary>Grid.Column attached property.</summary>
+    public static DOM.Attribute GridColumn(int value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Grid.Column", value.ToString(CultureInfo.InvariantCulture), id);
+
+    // =========================================================================
+    // Appearance
+    // =========================================================================
+
+    public static DOM.Attribute FontSize(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("FontSize", Num(value), id);
+
+    public static DOM.Attribute FontWeight(FontWeight value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("FontWeight", value.ToString(), id);
+
+    /// <summary>Foreground color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>
+    public static DOM.Attribute Foreground(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Foreground", color, id);
+
+    /// <summary>Background color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>
+    public static DOM.Attribute Background(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Background", color, id);
+
+    public static DOM.Attribute CornerRadius(double uniform, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("CornerRadius", Num(uniform), id);
+
+    public static DOM.Attribute BorderThickness(double uniform, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("BorderThickness", Num(uniform), id);
+
+    /// <summary>Border brush color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>
+    public static DOM.Attribute BorderBrush(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("BorderBrush", color, id);
+
+    public static DOM.Attribute Opacity(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Opacity", Num(value), id);
+
+    // =========================================================================
+    // Control state
+    // =========================================================================
+
+    public static DOM.Attribute IsEnabled(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("IsEnabled", value ? "True" : "False", id);
+
+    /// <summary>TextBox text (two-way: pair with OnTextChanged).</summary>
+    public static DOM.Attribute Text(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Text", value, id);
+
+    /// <summary>TextBox placeholder text.</summary>
+    public static DOM.Attribute PlaceholderText(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("PlaceholderText", value, id);
+
+    /// <summary>CheckBox checked state (pair with OnToggled).</summary>
+    public static DOM.Attribute IsChecked(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("IsChecked", value ? "True" : "False", id);
+
+    /// <summary>Slider minimum.</summary>
+    public static DOM.Attribute Minimum(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Minimum", Num(value), id);
+
+    /// <summary>Slider maximum.</summary>
+    public static DOM.Attribute Maximum(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Maximum", Num(value), id);
+
+    /// <summary>Slider value (pair with OnValueChanged).</summary>
+    public static DOM.Attribute Value(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Value", Num(value), id);
+
+    /// <summary>Image source URI.</summary>
+    public static DOM.Attribute Source(string uri, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Source", uri, id);
+}

--- a/Picea.Abies.Native/Rendering/INativeBackend.cs
+++ b/Picea.Abies.Native/Rendering/INativeBackend.cs
@@ -1,0 +1,89 @@
+// =============================================================================
+// Native Backend Abstraction
+// =============================================================================
+// The seam between the platform-neutral patch interpreter and a concrete UI
+// framework. Picea.Abies.WinUI implements this over WinUI/Uno
+// FrameworkElements; tests implement it with a fake recording backend.
+//
+// Child operations use DOM-like semantics (append / insert-before / move)
+// because that is what the Abies patch stream expresses; backends translate
+// to their framework's child collection model.
+// =============================================================================
+
+namespace Picea.Abies.Native.Rendering;
+
+/// <summary>
+/// Receives native control events from a backend and routes them to the
+/// registered Abies handler. Implemented by <see cref="PatchInterpreter{T}"/>.
+/// </summary>
+public interface INativeEventSink
+{
+    /// <summary>
+    /// Dispatches a native event to the handler registered for
+    /// (<paramref name="elementId"/>, <paramref name="eventName"/>).
+    /// </summary>
+    /// <param name="elementId">The virtual DOM id of the source element.</param>
+    /// <param name="eventName">The native event name (e.g., "Click").</param>
+    /// <param name="data">Native event data record (e.g., <see cref="TextChangedData"/>), or null for static-message handlers.</param>
+    void OnNativeEvent(string elementId, string eventName, object? data);
+
+    /// <summary>
+    /// True while a patch batch is being applied. Backends use this to
+    /// suppress event echo when a patch writes a property that raises the
+    /// same event a user edit would (e.g., TextBox.TextChanged).
+    /// </summary>
+    bool IsApplying { get; }
+}
+
+/// <summary>
+/// A concrete UI framework binding for the patch interpreter.
+/// </summary>
+/// <typeparam name="T">The framework's control base type (e.g., FrameworkElement).</typeparam>
+public interface INativeBackend<T> where T : class
+{
+    /// <summary>Creates a control instance for the given vocabulary tag.</summary>
+    T CreateControl(string tag, string elementId);
+
+    /// <summary>
+    /// Sets a property from its string-encoded attribute value;
+    /// <paramref name="value"/> null means reset to the default.
+    /// </summary>
+    void SetProperty(T control, string tag, string name, string? value);
+
+    /// <summary>
+    /// Appends a child to the parent's child collection (or content slot).
+    /// Insertions always append: the diff restores ordering with a following
+    /// <see cref="MoveChild"/>, so no positional-insert operation is needed.
+    /// </summary>
+    void AppendChild(T parent, string parentTag, T child);
+
+    /// <summary>Replaces an existing child in place.</summary>
+    void ReplaceChild(T parent, string parentTag, T oldChild, T newChild);
+
+    /// <summary>Removes a child.</summary>
+    void RemoveChild(T parent, string parentTag, T child);
+
+    /// <summary>
+    /// Moves an existing child before <paramref name="before"/>, or to the
+    /// end when <paramref name="before"/> is null (insertBefore semantics).
+    /// </summary>
+    void MoveChild(T parent, string parentTag, T child, T? before);
+
+    /// <summary>Removes all children.</summary>
+    void ClearChildren(T parent, string parentTag);
+
+    /// <summary>Installs the root control into the hosting surface.</summary>
+    void SetRoot(T root);
+
+    /// <summary>
+    /// Subscribes the control's native event named <paramref name="eventName"/>
+    /// and forwards occurrences to <paramref name="sink"/>. Implementations
+    /// must keep the subscription so <see cref="DetachEvent"/> can remove it,
+    /// and should honor <see cref="INativeEventSink.IsApplying"/> for events
+    /// that echo property writes.
+    /// </summary>
+    void AttachEvent(T control, string tag, string eventName, string elementId, INativeEventSink sink);
+
+    /// <summary>Removes a subscription installed by <see cref="AttachEvent"/>.</summary>
+    void DetachEvent(T control, string tag, string eventName);
+}

--- a/Picea.Abies.Native/Rendering/PatchInterpreter.cs
+++ b/Picea.Abies.Native/Rendering/PatchInterpreter.cs
@@ -213,22 +213,18 @@ public sealed class PatchInterpreter<T> : INativeEventSink where T : class
             }
         }
 
-        foreach (var child in element.Children)
-        {
-            if (Resolve(child) is Element childElement)
-                _backend.AppendChild(control, element.Tag, BuildSubtree(childElement, element.Id));
-        }
+        // Resolve unwraps memo nodes and throws on Text/RawHtml; OfType then
+        // skips Empty, which is the only other kind a native tree may contain.
+        foreach (var childElement in element.Children.Select(Resolve).OfType<Element>())
+            _backend.AppendChild(control, element.Tag, BuildSubtree(childElement, element.Id));
 
         return control;
     }
 
     private void AppendMaterialized(T parentControl, Element parent, Node[] children)
     {
-        foreach (var child in children)
-        {
-            if (Resolve(child) is Element childElement)
-                _backend.AppendChild(parentControl, parent.Tag, BuildSubtree(childElement, parent.Id));
-        }
+        foreach (var childElement in children.Select(Resolve).OfType<Element>())
+            _backend.AppendChild(parentControl, parent.Tag, BuildSubtree(childElement, parent.Id));
     }
 
     /// <summary>
@@ -295,14 +291,12 @@ public sealed class PatchInterpreter<T> : INativeEventSink where T : class
 
     private void UnregisterChildrenOf(string parentId)
     {
-        List<string>? doomed = null;
-        foreach (var (childId, pid) in _parents)
-        {
-            if (pid == parentId)
-                (doomed ??= []).Add(childId);
-        }
-        if (doomed is null)
-            return;
+        // Materialized before the loop: DropControl mutates _parents.
+        var doomed = _parents
+            .Where(entry => entry.Value == parentId)
+            .Select(entry => entry.Key)
+            .ToList();
+
         foreach (var childId in doomed)
         {
             UnregisterChildrenOf(childId);
@@ -331,13 +325,12 @@ public sealed class PatchInterpreter<T> : INativeEventSink where T : class
     /// </summary>
     private void DetachHandlersFor(string elementId)
     {
-        List<string>? doomed = null;
-        foreach (var key in _handlers.Keys)
-        {
-            if (key.ElementId == elementId)
-                (doomed ??= []).Add(key.EventName);
-        }
-        if (doomed is null)
+        // Materialized before the loop: the loop mutates _handlers.
+        var doomed = _handlers.Keys
+            .Where(key => key.ElementId == elementId)
+            .Select(key => key.EventName)
+            .ToList();
+        if (doomed.Count == 0)
             return;
 
         _controls.TryGetValue(elementId, out var control);

--- a/Picea.Abies.Native/Rendering/PatchInterpreter.cs
+++ b/Picea.Abies.Native/Rendering/PatchInterpreter.cs
@@ -1,0 +1,363 @@
+// =============================================================================
+// Patch Interpreter
+// =============================================================================
+// Interprets the Abies patch stream against an INativeBackend. This is the
+// native counterpart of abies.js's applyPatch: it owns the elementId →
+// control map, the (elementId, eventName) → Handler map, and child → parent
+// tracking (needed because ReplaceChild patches carry no parent).
+//
+// Threading: Apply must be called on the backend's UI thread. The hosting
+// adapter (e.g., Picea.Abies.WinUI) is responsible for marshaling — the
+// Abies runtime invokes its Apply delegate on whatever thread dispatched the
+// message.
+//
+// Native trees contain only Element nodes (see Elements.cs). The Text and
+// RawHtml patch families therefore throw here as a tripwire: if one fires,
+// a view produced a Text/RawHtml child and the diff took an HTML fallback.
+// =============================================================================
+
+using Picea.Abies.DOM;
+
+namespace Picea.Abies.Native.Rendering;
+
+/// <summary>
+/// Applies Abies patches to native controls via an <see cref="INativeBackend{T}"/>.
+/// </summary>
+/// <typeparam name="T">The framework's control base type.</typeparam>
+public sealed class PatchInterpreter<T> : INativeEventSink where T : class
+{
+    private readonly INativeBackend<T> _backend;
+    private readonly Dictionary<string, T> _controls = [];
+    private readonly Dictionary<string, string> _tags = [];
+    private readonly Dictionary<string, string> _parents = [];
+    private readonly Dictionary<(string ElementId, string EventName), Handler> _handlers = [];
+
+    public PatchInterpreter(INativeBackend<T> backend) => _backend = backend;
+
+    /// <summary>
+    /// Dispatches messages produced by native events into the Abies runtime.
+    /// Set once during bootstrap, before the first event can fire.
+    /// </summary>
+    public Func<Message, ValueTask>? Dispatch { get; set; }
+
+    /// <inheritdoc />
+    public bool IsApplying { get; private set; }
+
+    /// <summary>Number of live tracked controls (diagnostics/tests).</summary>
+    public int ControlCount => _controls.Count;
+
+    /// <summary>
+    /// Applies a patch batch. Must run on the backend's UI thread.
+    /// </summary>
+    public void Apply(IReadOnlyList<Patch> patches)
+    {
+        IsApplying = true;
+        try
+        {
+            foreach (var patch in patches)
+                ApplyPatch(patch);
+        }
+        finally
+        {
+            IsApplying = false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void OnNativeEvent(string elementId, string eventName, object? data)
+    {
+        if (!_handlers.TryGetValue((elementId, eventName), out var handler))
+            return;
+
+        var message = handler.Command ?? handler.WithData?.Invoke(data);
+        if (message is null)
+            return;
+
+        var dispatch = Dispatch
+            ?? throw new InvalidOperationException("PatchInterpreter.Dispatch is not wired to a runtime.");
+        _ = dispatch(message);
+    }
+
+    private void ApplyPatch(Patch patch)
+    {
+        switch (patch)
+        {
+            case AddRoot p:
+                Reset();
+                _backend.SetRoot(BuildSubtree(p.Element, parentId: null));
+                break;
+
+            case ReplaceChild p:
+            {
+                var oldControl = Control(p.OldElement.Id);
+                var parentId = _parents[p.OldElement.Id];
+                var parentControl = Control(parentId);
+                var parentTag = _tags[parentId];
+                // Unregister BEFORE building: old and new subtrees may share
+                // element ids (same view call sites), and building first would
+                // let the unregistration wipe the fresh registrations.
+                UnregisterSubtree(p.OldElement);
+                var newControl = BuildSubtree(p.NewElement, parentId);
+                _backend.ReplaceChild(parentControl, parentTag, oldControl, newControl);
+                break;
+            }
+
+            case AddChild p:
+                _backend.AppendChild(Control(p.Parent.Id), p.Parent.Tag,
+                    BuildSubtree(p.Child, p.Parent.Id));
+                break;
+
+            case RemoveChild p:
+                _backend.RemoveChild(Control(p.Parent.Id), p.Parent.Tag, Control(p.Child.Id));
+                UnregisterSubtree(p.Child);
+                break;
+
+            case ClearChildren p:
+                _backend.ClearChildren(Control(p.Parent.Id), p.Parent.Tag);
+                foreach (var child in p.OldChildren)
+                    UnregisterSubtree(child);
+                break;
+
+            case SetChildrenHtml p:
+            {
+                // 0→N children fast path; clear defensively in case the diff
+                // ever uses it as a full replacement.
+                var parentControl = Control(p.Parent.Id);
+                _backend.ClearChildren(parentControl, p.Parent.Tag);
+                UnregisterChildrenOf(p.Parent.Id);
+                AppendMaterialized(parentControl, p.Parent, p.Children);
+                break;
+            }
+
+            case AppendChildrenHtml p:
+                AppendMaterialized(Control(p.Parent.Id), p.Parent, p.Children);
+                break;
+
+            case MoveChild p:
+                _backend.MoveChild(Control(p.Parent.Id), p.Parent.Tag, Control(p.Child.Id),
+                    p.BeforeId is null ? null : Control(p.BeforeId));
+                break;
+
+            case UpdateAttribute p:
+                SetProperty(p.Element, p.Attribute.Name, p.Value);
+                break;
+
+            case AddAttribute p:
+                if (p.Attribute is Handler addedHandler)
+                    AddHandlerToLiveControl(p.Element, addedHandler);
+                else
+                    SetProperty(p.Element, p.Attribute.Name, p.Attribute.Value);
+                break;
+
+            case RemoveAttribute p:
+                if (p.Attribute is Handler removedHandler)
+                    RemoveHandlerFromLiveControl(p.Element, removedHandler.EventName);
+                else
+                    SetProperty(p.Element, p.Attribute.Name, null);
+                break;
+
+            case AddHandler p:
+                AddHandlerToLiveControl(p.Element, p.Handler);
+                break;
+
+            case RemoveHandler p:
+                RemoveHandlerFromLiveControl(p.Element, p.Handler.EventName);
+                break;
+
+            case UpdateHandler p:
+                // Same CommandId, fresh closure: swap the stored handler only —
+                // the native event subscription stays in place.
+                _handlers[(p.Element.Id, p.NewHandler.EventName)] = p.NewHandler;
+                break;
+
+            case UpdateText or AddText or RemoveText or AddRaw or RemoveRaw or ReplaceRaw or UpdateRaw:
+                throw new NotSupportedException(
+                    $"Patch {patch.GetType().Name} is not supported in native trees: " +
+                    "Text and RawHtml nodes must not appear in native views. " +
+                    "Use TextBlock(...) or a Content-bearing control instead.");
+
+            case AddHeadElement or UpdateHeadElement or RemoveHeadElement:
+                break; // no document head natively
+
+            default:
+                throw new NotSupportedException($"Unknown patch type: {patch.GetType().Name}");
+        }
+    }
+
+    // =========================================================================
+    // Tree construction
+    // =========================================================================
+
+    private T BuildSubtree(Element element, string? parentId)
+    {
+        var control = _backend.CreateControl(element.Tag, element.Id);
+        _controls[element.Id] = control;
+        _tags[element.Id] = element.Tag;
+        if (parentId is not null)
+            _parents[element.Id] = parentId;
+        else
+            _parents.Remove(element.Id);
+
+        foreach (var attribute in element.Attributes)
+        {
+            if (attribute is Handler handler)
+            {
+                // Fresh control: always attach, even if a same-id entry
+                // lingers from a subtree that is about to be unregistered.
+                _handlers[(element.Id, handler.EventName)] = handler;
+                _backend.AttachEvent(control, element.Tag, handler.EventName, element.Id, this);
+            }
+            else if (!IsVirtualAttribute(attribute.Name))
+            {
+                _backend.SetProperty(control, element.Tag, attribute.Name, attribute.Value);
+            }
+        }
+
+        foreach (var child in element.Children)
+        {
+            if (Resolve(child) is Element childElement)
+                _backend.AppendChild(control, element.Tag, BuildSubtree(childElement, element.Id));
+        }
+
+        return control;
+    }
+
+    private void AppendMaterialized(T parentControl, Element parent, Node[] children)
+    {
+        foreach (var child in children)
+        {
+            if (Resolve(child) is Element childElement)
+                _backend.AppendChild(parentControl, parent.Tag, BuildSubtree(childElement, parent.Id));
+        }
+    }
+
+    /// <summary>
+    /// Unwraps Memo/LazyMemo wrappers and rejects node kinds that native
+    /// trees must not contain. Empty resolves to itself and is skipped by
+    /// callers; Text/RawHtml throw the same tripwire as their patches.
+    /// </summary>
+    private static Node Resolve(Node node) => node switch
+    {
+        MemoNode memo => Resolve(memo.CachedNode),
+        LazyMemoNode lazy => Resolve(lazy.CachedNode ?? lazy.Evaluate()),
+        Text or RawHtml => throw new NotSupportedException(
+            "Text and RawHtml nodes are not supported in native trees. " +
+            "Use TextBlock(...) or a Content-bearing control instead."),
+        _ => node,
+    };
+
+    // =========================================================================
+    // Bookkeeping
+    // =========================================================================
+
+    private T Control(string elementId) =>
+        _controls.TryGetValue(elementId, out var control)
+            ? control
+            : throw new InvalidOperationException($"No native control tracked for element id '{elementId}'.");
+
+    private void SetProperty(Element element, string name, string? value)
+    {
+        if (IsVirtualAttribute(name))
+            return;
+        _backend.SetProperty(Control(element.Id), element.Tag, name, value);
+    }
+
+    private static bool IsVirtualAttribute(string name) =>
+        name is "key" or "data-key" or "id";
+
+    /// <summary>A live control gains a handler for an event it had none for.</summary>
+    private void AddHandlerToLiveControl(Element element, Handler handler)
+    {
+        var key = (element.Id, handler.EventName);
+        var alreadyAttached = _handlers.ContainsKey(key);
+        _handlers[key] = handler;
+        if (!alreadyAttached)
+            _backend.AttachEvent(Control(element.Id), element.Tag, handler.EventName, element.Id, this);
+    }
+
+    private void RemoveHandlerFromLiveControl(Element element, string eventName)
+    {
+        if (_handlers.Remove((element.Id, eventName)))
+            _backend.DetachEvent(Control(element.Id), element.Tag, eventName);
+    }
+
+    /// <summary>Drops all tracking for a removed subtree.</summary>
+    private void UnregisterSubtree(Node node)
+    {
+        if (Resolve(node) is not Element element)
+            return;
+
+        foreach (var child in element.Children)
+            UnregisterSubtree(child);
+
+        DropControl(element.Id);
+    }
+
+    private void UnregisterChildrenOf(string parentId)
+    {
+        List<string>? doomed = null;
+        foreach (var (childId, pid) in _parents)
+        {
+            if (pid == parentId)
+                (doomed ??= []).Add(childId);
+        }
+        if (doomed is null)
+            return;
+        foreach (var childId in doomed)
+        {
+            UnregisterChildrenOf(childId);
+            DropControl(childId);
+        }
+    }
+
+    /// <summary>
+    /// Stops tracking a control, detaching its native event subscriptions
+    /// first. Every path that drops a control must go through here: a backend
+    /// keyed on the control instance (as the WinUI one is) otherwise keeps the
+    /// dead control and its handler closures alive for the process lifetime.
+    /// </summary>
+    private void DropControl(string elementId)
+    {
+        DetachHandlersFor(elementId);
+        _controls.Remove(elementId);
+        _tags.Remove(elementId);
+        _parents.Remove(elementId);
+    }
+
+    /// <summary>
+    /// Detaches and forgets every handler registered for an element. Reads the
+    /// live handler map rather than the node's attributes, so handlers added by
+    /// later AddHandler patches are detached too.
+    /// </summary>
+    private void DetachHandlersFor(string elementId)
+    {
+        List<string>? doomed = null;
+        foreach (var key in _handlers.Keys)
+        {
+            if (key.ElementId == elementId)
+                (doomed ??= []).Add(key.EventName);
+        }
+        if (doomed is null)
+            return;
+
+        _controls.TryGetValue(elementId, out var control);
+        var tag = _tags.GetValueOrDefault(elementId, string.Empty);
+        foreach (var eventName in doomed)
+        {
+            _handlers.Remove((elementId, eventName));
+            if (control is not null)
+                _backend.DetachEvent(control, tag, eventName);
+        }
+    }
+
+    private void Reset()
+    {
+        foreach (var elementId in _handlers.Keys.Select(key => key.ElementId).Distinct().ToArray())
+            DetachHandlersFor(elementId);
+
+        _controls.Clear();
+        _tags.Clear();
+        _parents.Clear();
+        _handlers.Clear();
+    }
+}

--- a/Picea.Abies.sln
+++ b/Picea.Abies.sln
@@ -91,6 +91,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Testing.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Cli", "Picea.Abies.Cli\Picea.Abies.Cli.csproj", "{E31A97BB-14C9-46DB-915D-EF9522A0284F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Native", "Picea.Abies.Native\Picea.Abies.Native.csproj", "{B83D26EC-41D8-46BC-A1FA-A487826F8F65}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Native.Tests", "Picea.Abies.Native.Tests\Picea.Abies.Native.Tests.csproj", "{146E64A1-2274-401C-ABE5-8F9F1778C54B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -629,6 +633,30 @@ Global
 		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x64.Build.0 = Release|Any CPU
 		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E31A97BB-14C9-46DB-915D-EF9522A0284F}.Release|x86.Build.0 = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|x64.Build.0 = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Debug|x86.Build.0 = Debug|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|x64.ActiveCfg = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|x64.Build.0 = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|x86.ActiveCfg = Release|Any CPU
+		{B83D26EC-41D8-46BC-A1FA-A487826F8F65}.Release|x86.Build.0 = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|x64.Build.0 = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Debug|x86.Build.0 = Debug|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x64.ActiveCfg = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x64.Build.0 = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x86.ActiveCfg = Release|Any CPU
+		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
First of four PRs landing the WinUI native renderer spike (`spike/winui-native-renderer`). This one is deliberately self-contained: **no Uno, no `global.json` change, no UI framework dependency**, so it carries no CI risk.

### What

Adds `Picea.Abies.Native` and `Picea.Abies.Native.Tests`:

- **Vocabulary** (`Elements`/`Properties`/`Events`) describing native controls as ordinary Abies virtual DOM elements — the diff and patch machinery are vocabulary-agnostic and reused unchanged.
- **`PatchInterpreter<T>`** over an `INativeBackend<T>` seam: owns the elementId→control map, the (elementId, eventName)→Handler map, and child→parent tracking. Platform-neutral and testable headlessly.
- **19 tests** driving the real `Operations.Diff` (not hand-built patch lists) against a recording `FakeBackend`.

`Picea.Abies` is **not modified**. The renderer plugs into the existing `Apply(IReadOnlyList<Patch>)` delegate exactly as the browser and server renderers do.

### Why

Establishes native rendering as a third `Apply` implementation rather than a fork, so Model/Transition/Decide/Subscriptions stay shared across web, server and native. Landing the platform-neutral half first keeps the Uno/WinUI toolchain (and its CI cost) out of this PR entirely.

The key design constraint: native trees contain **only `Element` nodes** — text is a `Text`/`Content` attribute, never a `Text` child. That structurally prevents the diff's HTML fallback paths (`ReplaceRaw`/`Render.Html`) from firing. The interpreter throws on the Text/RawHtml patch families as a tripwire, with tests covering it.

### Changes made to the spike code

Three fixes on top of the extracted spike:

1. **Event-subscription leak (bug).** Only `RemoveHandler`/`RemoveAttribute` reached `DetachEvent`. Subtree removal, replacement and root swaps dropped interpreter bookkeeping while leaving the backend subscribed — a backend keyed on the control instance (as the WinUI one is) would retain dead controls and their closures for the process lifetime. All teardown now routes through `DropControl`/`DetachHandlersFor`, which read the live handler map so handlers added by later `AddHandler` patches are detached too.
2. **Removed `INativeBackend.InsertBefore`.** Never called — insertions append and the diff restores ordering with a following `MoveChild`. Replaced with a test pinning that behaviour rather than leaving unused surface on a public interface.
3. **`Picea.Abies.Native.Tests` added to the CD test list**, which enumerates test projects explicitly (it would otherwise have built but never run).

### Testing

- `dotnet test Picea.Abies.Native.Tests` → **19/19 passing**.
- The three new detach tests were verified to **fail against the pre-fix interpreter** and pass after, so they genuinely pin the leak.
- `dotnet format --verify-no-changes --exclude-diagnostics IDE1006` → clean (exit 0) for both projects.
- New coverage: subtree-removal detach, subtree-replacement detach, root-swap detach, and mid-list insertion ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)