### PR TITLE
feat(winui): Add WinUI backend and Uno desktop head

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,6 +73,16 @@ jobs:
         dotnet-version: '10.0.x'
     - name: Install WASM experimental workload
       run: dotnet workload install wasm-experimental wasm-tools
+    # The solution includes Uno.Sdk projects (Picea.Abies.WinUI), whose SDK and
+    # package graph are resolved on restore. Caching keeps that off the
+    # critical path.
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
     - name: Restore dependencies
       run: dotnet restore
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -747,6 +747,17 @@ jobs:
       - name: Install WASM workloads
         run: dotnet workload install wasm-experimental wasm-tools
 
+      # The solution includes Uno.Sdk projects (Picea.Abies.WinUI), whose SDK
+      # and package graph are resolved on restore. Caching keeps that off the
+      # critical path for every PR.
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Restore
         run: dotnet restore
         env:

--- a/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
+++ b/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Uno.Sdk">
+  <PropertyGroup>
+    <!-- Spike: desktop (Skia) head only. Add net10.0-windows10.0.26100 on a
+         Windows machine to target Windows App SDK / real WinUI 3. -->
+    <TargetFrameworks>net10.0-desktop</TargetFrameworks>
+    <UnoSingleProject>true</UnoSingleProject>
+    <OutputType>Library</OutputType>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Picea.Abies.Native\Picea.Abies.Native.csproj" />
+  </ItemGroup>
+</Project>

--- a/Picea.Abies.WinUI/Runtime.cs
+++ b/Picea.Abies.WinUI/Runtime.cs
@@ -1,0 +1,79 @@
+// =============================================================================
+// WinUI Runtime Bootstrap
+// =============================================================================
+// One-line entry point mirroring Picea.Abies.Browser.Runtime.Run: wires the
+// patch interpreter + WinUI backend into the Abies runtime.
+//
+// Threading: the Abies runtime invokes its Apply delegate on whatever thread
+// dispatched the message (subscriptions run on the thread pool), so Apply
+// marshals to the window's DispatcherQueue. threadSafe: true serializes the
+// Picea core for the same reason.
+// =============================================================================
+
+using Picea.Abies.Native.Rendering;
+using Picea.Abies.Subscriptions;
+
+namespace Picea.Abies.WinUI;
+
+/// <summary>
+/// Bootstraps an Abies program onto a WinUI window.
+/// </summary>
+public static class Runtime
+{
+    /// <summary>
+    /// Starts an Abies program rendering into <paramref name="rootHost"/>.
+    /// </summary>
+    /// <param name="rootHost">The panel that receives the root control (e.g., the window's content grid).</param>
+    /// <param name="window">The hosting window; receives Document.Title updates.</param>
+    /// <param name="argument">The program's initialization argument.</param>
+    /// <param name="interpreter">Command interpreter for the program's effects; defaults to a no-op.</param>
+    /// <param name="subscriptionFaulted">Callback for subscription failures.</param>
+    public static async Task<Runtime<TProgram, TModel, TArgument>> Run<TProgram, TModel, TArgument>(
+        Panel rootHost,
+        Window window,
+        TArgument argument = default!,
+        Interpreter<Command, Message>? interpreter = null,
+        Action<SubscriptionFault>? subscriptionFaulted = null)
+        where TProgram : Program<TModel, TArgument>
+    {
+        var dispatcherQueue = rootHost.DispatcherQueue;
+        var backend = new WinUIBackend(rootHost);
+        var patchInterpreter = new PatchInterpreter<FrameworkElement>(backend);
+
+        Runtime<TProgram, TModel, TArgument>? runtime = null;
+        patchInterpreter.Dispatch = async message =>
+        {
+            if (runtime is not null)
+                await runtime.Dispatch(message);
+        };
+
+        void Apply(IReadOnlyList<Patch> patches)
+        {
+            if (dispatcherQueue.HasThreadAccess)
+                patchInterpreter.Apply(patches);
+            else
+                dispatcherQueue.TryEnqueue(() => patchInterpreter.Apply(patches));
+        }
+
+        void TitleChanged(string title)
+        {
+            if (dispatcherQueue.HasThreadAccess)
+                window.Title = title;
+            else
+                dispatcherQueue.TryEnqueue(() => window.Title = title);
+        }
+
+        runtime = await Runtime<TProgram, TModel, TArgument>.Start(
+            Apply,
+            interpreter ?? NoOpInterpreter,
+            argument,
+            titleChanged: TitleChanged,
+            subscriptionFaulted: subscriptionFaulted,
+            threadSafe: true);
+
+        return runtime;
+    }
+
+    private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>
+        ValueTask.FromResult(Result<Message[], PipelineError>.Ok([]));
+}

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -1,0 +1,519 @@
+// =============================================================================
+// WinUI Backend
+// =============================================================================
+// INativeBackend implementation over the WinUI 3 API surface
+// (Microsoft.UI.Xaml). Runs on Windows App SDK and, via Uno Platform, on
+// macOS/Linux/WebAssembly — this code has no Uno-specific API usage.
+//
+// String-encoded attribute values are parsed here into native types
+// (double, Thickness, GridLength, Brush, enums). Unknown tags or properties
+// throw: in a spike, silence hides bugs.
+// =============================================================================
+
+using System.Globalization;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Picea.Abies.Native;
+using Picea.Abies.Native.Rendering;
+using Windows.UI;
+
+namespace Picea.Abies.WinUI;
+
+/// <summary>
+/// Binds the platform-neutral patch interpreter to WinUI controls.
+/// </summary>
+public sealed class WinUIBackend : INativeBackend<FrameworkElement>
+{
+    private readonly Panel _rootHost;
+    private readonly Dictionary<(FrameworkElement Control, string EventName), Action> _detachers = [];
+
+    /// <param name="rootHost">The panel that receives the root control (e.g., the window's content grid).</param>
+    public WinUIBackend(Panel rootHost) => _rootHost = rootHost;
+
+    // =========================================================================
+    // Control factory
+    // =========================================================================
+
+    public FrameworkElement CreateControl(string tag, string elementId) => tag switch
+    {
+        "StackPanel" => new StackPanel(),
+        "Grid" => new Grid(),
+        "Border" => new Border(),
+        "ScrollViewer" => new ScrollViewer(),
+        "TextBlock" => new TextBlock(),
+        "Button" => new Button(),
+        "TextBox" => new TextBox(),
+        "CheckBox" => new CheckBox(),
+        "Slider" => new Slider(),
+        "Image" => new Image(),
+        _ => throw new NotSupportedException($"Unknown native tag '{tag}' (element '{elementId}')."),
+    };
+
+    // =========================================================================
+    // Properties
+    // =========================================================================
+
+    public void SetProperty(FrameworkElement control, string tag, string name, string? value)
+    {
+        // FrameworkElement-level properties, any control.
+        switch (name)
+        {
+            case "Width":
+                if (value is null)
+                    control.ClearValue(FrameworkElement.WidthProperty);
+                else
+                    control.Width = D(value);
+                return;
+            case "Height":
+                if (value is null)
+                    control.ClearValue(FrameworkElement.HeightProperty);
+                else
+                    control.Height = D(value);
+                return;
+            case "Margin":
+                if (value is null)
+                    control.ClearValue(FrameworkElement.MarginProperty);
+                else
+                    control.Margin = ParseThickness(value);
+                return;
+            case "Opacity":
+                if (value is null)
+                    control.ClearValue(UIElement.OpacityProperty);
+                else
+                    control.Opacity = D(value);
+                return;
+            case "HorizontalAlignment":
+                if (value is null)
+                    control.ClearValue(FrameworkElement.HorizontalAlignmentProperty);
+                else
+                    control.HorizontalAlignment = value switch
+                    {
+                        "Start" => HorizontalAlignment.Left,
+                        "Center" => HorizontalAlignment.Center,
+                        "End" => HorizontalAlignment.Right,
+                        _ => HorizontalAlignment.Stretch,
+                    };
+                return;
+            case "VerticalAlignment":
+                if (value is null)
+                    control.ClearValue(FrameworkElement.VerticalAlignmentProperty);
+                else
+                    control.VerticalAlignment = value switch
+                    {
+                        "Start" => VerticalAlignment.Top,
+                        "Center" => VerticalAlignment.Center,
+                        "End" => VerticalAlignment.Bottom,
+                        _ => VerticalAlignment.Stretch,
+                    };
+                return;
+            case "IsEnabled" when control is Control c:
+                c.IsEnabled = value is null || bool.Parse(value);
+                return;
+            case "FontSize" when control is TextBlock tbFs:
+                if (value is null)
+                    tbFs.ClearValue(TextBlock.FontSizeProperty);
+                else
+                    tbFs.FontSize = D(value);
+                return;
+            case "FontSize" when control is Control cFs:
+                if (value is null)
+                    cFs.ClearValue(Control.FontSizeProperty);
+                else
+                    cFs.FontSize = D(value);
+                return;
+            case "Grid.Row":
+                Grid.SetRow(control, I(value ?? "0"));
+                return;
+            case "Grid.Column":
+                Grid.SetColumn(control, I(value ?? "0"));
+                return;
+        }
+
+        // Control-specific properties.
+        switch (control)
+        {
+            case StackPanel sp:
+                switch (name)
+                {
+                    case "Orientation":
+                        sp.Orientation = value == "Horizontal"
+                            ? Microsoft.UI.Xaml.Controls.Orientation.Horizontal
+                            : Microsoft.UI.Xaml.Controls.Orientation.Vertical;
+                        return;
+                    case "Spacing":
+                        sp.Spacing = value is null ? 0 : D(value);
+                        return;
+                    case "Padding":
+                        sp.Padding = value is null ? default : ParseThickness(value);
+                        return;
+                    case "Background":
+                        SetBrush(sp, FrameworkElement.BackgroundProperty, value);
+                        return;
+                }
+                break;
+            case Grid g:
+                switch (name)
+                {
+                    case "RowDefinitions":
+                        g.RowDefinitions.Clear();
+                        foreach (var part in (value ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries))
+                            g.RowDefinitions.Add(new RowDefinition { Height = ParseGridLength(part.Trim()) });
+                        return;
+                    case "ColumnDefinitions":
+                        g.ColumnDefinitions.Clear();
+                        foreach (var part in (value ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries))
+                            g.ColumnDefinitions.Add(new ColumnDefinition { Width = ParseGridLength(part.Trim()) });
+                        return;
+                    case "Padding":
+                        g.Padding = value is null ? default : ParseThickness(value);
+                        return;
+                    case "Background":
+                        SetBrush(g, FrameworkElement.BackgroundProperty, value);
+                        return;
+                }
+                break;
+            case Border b:
+                switch (name)
+                {
+                    case "Padding":
+                        b.Padding = value is null ? default : ParseThickness(value);
+                        return;
+                    case "CornerRadius":
+                        b.CornerRadius = value is null ? default : new CornerRadius(D(value));
+                        return;
+                    case "BorderThickness":
+                        b.BorderThickness = value is null ? default : ParseThickness(value);
+                        return;
+                    case "BorderBrush":
+                        SetBrush(b, Border.BorderBrushProperty, value);
+                        return;
+                    case "Background":
+                        SetBrush(b, FrameworkElement.BackgroundProperty, value);
+                        return;
+                }
+                break;
+            case TextBlock tb:
+                switch (name)
+                {
+                    case "Text":
+                        tb.Text = value ?? "";
+                        return;
+                    case "FontWeight":
+                        tb.FontWeight = ParseFontWeight(value);
+                        return;
+                    case "Foreground":
+                        SetBrush(tb, TextBlock.ForegroundProperty, value);
+                        return;
+                }
+                break;
+            case TextBox tx:
+                switch (name)
+                {
+                    case "Text":
+                        // Only write on real change: rewriting identical text
+                        // still resets the caret on some platforms.
+                        var newText = value ?? "";
+                        if (tx.Text != newText)
+                            tx.Text = newText;
+                        return;
+                    case "PlaceholderText":
+                        tx.PlaceholderText = value ?? "";
+                        return;
+                }
+                break;
+            case CheckBox cb:
+                switch (name)
+                {
+                    case "Content":
+                        cb.Content = value;
+                        return;
+                    case "IsChecked":
+                        cb.IsChecked = value is not null && bool.Parse(value);
+                        return;
+                    case "Foreground":
+                        SetBrush(cb, Control.ForegroundProperty, value);
+                        return;
+                }
+                break;
+            case Slider s:
+                switch (name)
+                {
+                    case "Minimum":
+                        s.Minimum = value is null ? 0 : D(value);
+                        return;
+                    case "Maximum":
+                        s.Maximum = value is null ? 100 : D(value);
+                        return;
+                    case "Value":
+                        // Guard identical writes: re-setting Value re-raises
+                        // ValueChanged on some platforms.
+                        var newValue = value is null ? 0 : D(value);
+                        if (s.Value != newValue)
+                            s.Value = newValue;
+                        return;
+                }
+                break;
+            case Button btn:
+                switch (name)
+                {
+                    case "Content":
+                        btn.Content = value;
+                        return;
+                    case "Padding":
+                        btn.Padding = value is null ? default : ParseThickness(value);
+                        return;
+                    case "Foreground":
+                        SetBrush(btn, Control.ForegroundProperty, value);
+                        return;
+                    case "Background":
+                        SetBrush(btn, FrameworkElement.BackgroundProperty, value);
+                        return;
+                }
+                break;
+            case ScrollViewer sv:
+                switch (name)
+                {
+                    case "Padding":
+                        sv.Padding = value is null ? default : ParseThickness(value);
+                        return;
+                }
+                break;
+            case Image img:
+                switch (name)
+                {
+                    case "Source":
+                        img.Source = value is null ? null : new BitmapImage(new Uri(value, UriKind.RelativeOrAbsolute));
+                        return;
+                }
+                break;
+        }
+
+        throw new NotSupportedException($"Property '{name}' is not supported on tag '{tag}'.");
+    }
+
+    // =========================================================================
+    // Children
+    // =========================================================================
+
+    public void AppendChild(FrameworkElement parent, string parentTag, FrameworkElement child)
+    {
+        switch (parent)
+        {
+            case Panel p:
+                p.Children.Add(child);
+                return;
+            case Border b:
+                b.Child = child;
+                return;
+            case ContentControl cc:
+                cc.Content = child;
+                return;
+        }
+        throw ChildrenNotSupported(parentTag);
+    }
+
+    public void ReplaceChild(FrameworkElement parent, string parentTag, FrameworkElement oldChild, FrameworkElement newChild)
+    {
+        switch (parent)
+        {
+            case Panel p:
+                p.Children[p.Children.IndexOf(oldChild)] = newChild;
+                return;
+            case Border b:
+                b.Child = newChild;
+                return;
+            case ContentControl cc:
+                cc.Content = newChild;
+                return;
+        }
+        throw ChildrenNotSupported(parentTag);
+    }
+
+    public void RemoveChild(FrameworkElement parent, string parentTag, FrameworkElement child)
+    {
+        switch (parent)
+        {
+            case Panel p:
+                p.Children.Remove(child);
+                return;
+            case Border b when ReferenceEquals(b.Child, child):
+                b.Child = null;
+                return;
+            case ContentControl cc when ReferenceEquals(cc.Content, child):
+                cc.Content = null;
+                return;
+        }
+    }
+
+    public void MoveChild(FrameworkElement parent, string parentTag, FrameworkElement child, FrameworkElement? before)
+    {
+        if (parent is not Panel p)
+            return; // single-child hosts have nothing to reorder
+        p.Children.Remove(child);
+        if (before is null)
+            p.Children.Add(child);
+        else
+            p.Children.Insert(p.Children.IndexOf(before), child);
+    }
+
+    public void ClearChildren(FrameworkElement parent, string parentTag)
+    {
+        switch (parent)
+        {
+            case Panel p:
+                p.Children.Clear();
+                return;
+            case Border b:
+                b.Child = null;
+                return;
+            case ContentControl cc:
+                cc.Content = null;
+                return;
+        }
+    }
+
+    public void SetRoot(FrameworkElement root)
+    {
+        _rootHost.Children.Clear();
+        _rootHost.Children.Add(root);
+    }
+
+    private static NotSupportedException ChildrenNotSupported(string parentTag) =>
+        new($"Tag '{parentTag}' does not support element children.");
+
+    // =========================================================================
+    // Events
+    // =========================================================================
+
+    public void AttachEvent(FrameworkElement control, string tag, string eventName, string elementId, INativeEventSink sink)
+    {
+        switch (control, eventName)
+        {
+            case (ButtonBase button, "Click"):
+            {
+                RoutedEventHandler handler = (_, _) => sink.OnNativeEvent(elementId, "Click", null);
+                button.Click += handler;
+                _detachers[(control, eventName)] = () => button.Click -= handler;
+                return;
+            }
+            case (TextBox textBox, "TextChanged"):
+            {
+                TextChangedEventHandler handler = (s, _) =>
+                {
+                    if (!sink.IsApplying)
+                        sink.OnNativeEvent(elementId, "TextChanged", new TextChangedData(((TextBox)s).Text));
+                };
+                textBox.TextChanged += handler;
+                _detachers[(control, eventName)] = () => textBox.TextChanged -= handler;
+                return;
+            }
+            case (CheckBox checkBox, "Toggled"):
+            {
+                RoutedEventHandler handler = (s, _) =>
+                {
+                    if (!sink.IsApplying)
+                        sink.OnNativeEvent(elementId, "Toggled", new ToggledData(((CheckBox)s).IsChecked == true));
+                };
+                checkBox.Checked += handler;
+                checkBox.Unchecked += handler;
+                _detachers[(control, eventName)] = () =>
+                {
+                    checkBox.Checked -= handler;
+                    checkBox.Unchecked -= handler;
+                };
+                return;
+            }
+            case (Slider slider, "ValueChanged"):
+            {
+                RangeBaseValueChangedEventHandler handler = (_, e) =>
+                {
+                    if (!sink.IsApplying)
+                        sink.OnNativeEvent(elementId, "ValueChanged", new ValueChangedData(e.NewValue, e.OldValue));
+                };
+                slider.ValueChanged += handler;
+                _detachers[(control, eventName)] = () => slider.ValueChanged -= handler;
+                return;
+            }
+        }
+
+        throw new NotSupportedException($"Event '{eventName}' is not supported on tag '{tag}'.");
+    }
+
+    public void DetachEvent(FrameworkElement control, string tag, string eventName)
+    {
+        if (_detachers.Remove((control, eventName), out var detach))
+            detach();
+    }
+
+    // =========================================================================
+    // Parsing
+    // =========================================================================
+
+    private static double D(string value) => double.Parse(value, CultureInfo.InvariantCulture);
+    private static int I(string value) => int.Parse(value, CultureInfo.InvariantCulture);
+
+    private static Thickness ParseThickness(string value)
+    {
+        var parts = value.Split(',');
+        return parts.Length switch
+        {
+            1 => new Thickness(D(parts[0])),
+            4 => new Thickness(D(parts[0]), D(parts[1]), D(parts[2]), D(parts[3])),
+            _ => throw new FormatException($"Invalid Thickness '{value}' — expected 1 or 4 comma-separated numbers."),
+        };
+    }
+
+    private static GridLength ParseGridLength(string part) => part switch
+    {
+        "Auto" or "auto" => GridLength.Auto,
+        "*" => new GridLength(1, GridUnitType.Star),
+        _ when part.EndsWith('*') => new GridLength(D(part[..^1]), GridUnitType.Star),
+        _ => new GridLength(D(part), GridUnitType.Pixel),
+    };
+
+    private static Windows.UI.Text.FontWeight ParseFontWeight(string? value) => value switch
+    {
+        "Bold" => Microsoft.UI.Text.FontWeights.Bold,
+        "SemiBold" => Microsoft.UI.Text.FontWeights.SemiBold,
+        _ => Microsoft.UI.Text.FontWeights.Normal,
+    };
+
+    /// <summary>
+    /// Sets a brush property, or clears it back to its theme default when
+    /// <paramref name="value"/> is null (i.e. the attribute was removed).
+    /// </summary>
+    private static void SetBrush(DependencyObject target, DependencyProperty property, string? value)
+    {
+        if (value is null)
+            target.ClearValue(property);
+        else
+            target.SetValue(property, new SolidColorBrush(ParseColor(value)));
+    }
+
+    private static Color ParseColor(string value)
+    {
+        if (value.StartsWith('#'))
+        {
+            var hex = value[1..];
+            return hex.Length switch
+            {
+                6 => Color.FromArgb(0xFF, H(hex, 0), H(hex, 2), H(hex, 4)),
+                8 => Color.FromArgb(H(hex, 0), H(hex, 2), H(hex, 4), H(hex, 6)),
+                _ => throw new FormatException($"Invalid color '{value}' — expected #RRGGBB or #AARRGGBB."),
+            };
+        }
+        return value.ToLowerInvariant() switch
+        {
+            "black" => Microsoft.UI.Colors.Black,
+            "white" => Microsoft.UI.Colors.White,
+            "red" => Microsoft.UI.Colors.Red,
+            "green" => Microsoft.UI.Colors.Green,
+            "blue" => Microsoft.UI.Colors.Blue,
+            "gray" or "grey" => Microsoft.UI.Colors.Gray,
+            "transparent" => Microsoft.UI.Colors.Transparent,
+            _ => throw new FormatException($"Unknown color name '{value}'."),
+        };
+
+        static byte H(string hex, int offset) => byte.Parse(hex.AsSpan(offset, 2), NumberStyles.HexNumber);
+    }
+}

--- a/Picea.Abies.sln
+++ b/Picea.Abies.sln
@@ -95,6 +95,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Native", "Picea
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.Native.Tests", "Picea.Abies.Native.Tests\Picea.Abies.Native.Tests.csproj", "{146E64A1-2274-401C-ABE5-8F9F1778C54B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Picea.Abies.WinUI", "Picea.Abies.WinUI\Picea.Abies.WinUI.csproj", "{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -657,6 +659,18 @@ Global
 		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x64.Build.0 = Release|Any CPU
 		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x86.ActiveCfg = Release|Any CPU
 		{146E64A1-2274-401C-ABE5-8F9F1778C54B}.Release|x86.Build.0 = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|x64.Build.0 = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Debug|x86.Build.0 = Debug|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|x64.ActiveCfg = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|x64.Build.0 = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|x86.ActiveCfg = Release|Any CPU
+		{E07BCB75-1CD0-47AC-AFED-0609AA5F6CCE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/global.json
+++ b/global.json
@@ -4,6 +4,9 @@
     "rollForward": "latestMajor",
     "allowPrerelease": false
   },
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.6.33"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
Second of four PRs landing the WinUI native renderer spike. **Stacked on #321** — review/merge that first; this PR's base will retarget to `main` automatically.

### What

Adds `Picea.Abies.WinUI`:

- **`WinUIBackend`** — `INativeBackend<FrameworkElement>` over the WinUI 3 API surface (`Microsoft.UI.Xaml`): control factory, string→native property parsing (`Thickness`, `GridLength`, `Brush`, enums), and event wiring with `IsApplying` echo suppression.
- **`Runtime.Run`** — one-line bootstrap that marshals `Apply` to the window's `DispatcherQueue` (the Abies runtime invokes `Apply` on whatever thread dispatched the message; subscriptions run on the thread pool).
- `Uno.Sdk` pin in `global.json` and the solution entry.

No Uno-specific APIs are used — Uno is the vehicle that makes the WinUI surface run cross-platform.

### Why

This is the concrete backend behind the platform-neutral interpreter in #321. Keeping it in its own project means a future Avalonia or AppKit backend reuses the vocabulary and interpreter unchanged, and shared app code never references a UI framework.

### ⚠️ Scope note

This adds the **`net10.0-desktop` (Uno Skia) head only.** The `net10.0-windows10.0.26100` head that exercises real WinUI 3 is a deliberate follow-up along with a `windows-latest` CI job. Until then this is an Uno Skia renderer with a WinUI-shaped API — worth being explicit about given the project name.

### Changes made to the spike code

- **Brush reset (bug).** `Foreground`/`Background` used `ParseBrushOrNull(value) ?? control.Foreground`, so removing the attribute silently kept the old colour while every other property path reset correctly. Now clears back to the theme default via `ClearValue`.
- **`Slider.Value` identical-write guard**, matching the existing `TextBox.Text` guard — re-setting `Value` re-raises `ValueChanged` on some platforms.
- Dropped the `InsertBefore` implementation to match the trimmed interface from #321.
- Formatting brought in line with `dotnet format` (the spike had `WHITESPACE` and `IMPORTS` errors that would have failed the required lint job).

### CI impact

The solution now contains Uno.Sdk projects, so every root `dotnet restore` resolves the Uno SDK and package graph.

- **Verified**: restore and build both succeed on Linux with **no workload install** (cold restore ~44s, WinUI build ~2s).
- **Verified**: `dotnet list package --vulnerable --include-transitive` over the Uno graph reports nothing.
- **Mitigation**: NuGet package caching added to the PR-validation and CD build jobs, following the existing `actions/cache@v4` style in `e2e.yml`.

### Testing

- `dotnet build Picea.Abies.WinUI` → 0 warnings, 0 errors.
- `dotnet format --verify-no-changes --exclude-diagnostics IDE1006` → clean (exit 0).
- `dotnet test Picea.Abies.Native.Tests` → 19/19 still passing.
- Both modified workflow files parse as valid YAML.
- Backend behaviour is covered indirectly through the interpreter tests in #321; direct WinUI coverage needs a UI thread and arrives with the Windows head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)