### PR TITLE
feat(winui): Add the Windows App SDK head and a windows-latest CI job

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -766,6 +766,47 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
+  # Real WinUI 3 via Windows App SDK. Every other job runs on Linux, where
+  # Picea.Abies.WinUI resolves to the Uno Skia desktop head only — this is the
+  # sole job that compiles the WinUI 3 target the renderer is named for.
+  winui-windows:
+    name: WinUI (Windows App SDK)
+    runs-on: windows-latest
+    needs: [detect-changes]
+    if: github.event.pull_request.draft == false && needs.detect-changes.outputs.docs_only == 'false'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET (from global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      # Both projects resolve two TFMs here: net10.0-desktop (Skia) and
+      # net10.0-windows10.0.26100 (Windows App SDK). Building the project files
+      # directly keeps this job off the rest of the solution, which is already
+      # covered on Linux.
+      - name: Build Picea.Abies.WinUI (Skia + Windows App SDK heads)
+        run: dotnet build Picea.Abies.WinUI/Picea.Abies.WinUI.csproj -c Release
+
+      - name: Build native Counter sample (Skia + Windows App SDK heads)
+        run: dotnet build Picea.Abies.Counter.Native/Picea.Abies.Counter.Native.csproj -c Release
+
+      - name: Test Picea.Abies.Native.Tests
+        run: dotnet test --project Picea.Abies.Native.Tests/Picea.Abies.Native.Tests.csproj
+
   # Check for TODO/FIXME without issues
   check-todos:
     name: Check TODOs

--- a/Picea.Abies.Counter.Native/Picea.Abies.Counter.Native.csproj
+++ b/Picea.Abies.Counter.Native/Picea.Abies.Counter.Native.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <!-- Spike: desktop (Skia) head only — runs on macOS/Linux/Windows.
-         Add net10.0-windows10.0.26100 on a Windows machine for the
-         Windows App SDK / real WinUI 3 head. -->
+    <!-- Skia desktop head runs on Linux/macOS/Windows; the Windows App SDK
+         head is real WinUI 3 and is only buildable on Windows. -->
     <TargetFrameworks>net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net10.0-windows10.0.26100</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/Picea.Abies.WinUI/.editorconfig
+++ b/Picea.Abies.WinUI/.editorconfig
@@ -1,0 +1,14 @@
+# Picea.Abies.WinUI targets two heads with different type hierarchies:
+# the Uno Skia desktop head and the Windows App SDK (real WinUI 3) head.
+#
+# Uno declares the Background dependency property on FrameworkElement, while
+# WinUI 3 declares it separately on Panel, Border and Control. IDE0002
+# ("simplify member access") is evaluated against whichever head the tooling
+# happens to load — on Linux that is always Uno — and rewrites
+# `Panel.BackgroundProperty` to `FrameworkElement.BackgroundProperty`, which
+# does not exist in WinUI 3 and fails the Windows build.
+#
+# Access through the derived type is valid on both heads, so it is the portable
+# spelling; this disables the rule that would rewrite it into the Uno-only one.
+[*.cs]
+dotnet_diagnostic.IDE0002.severity = none

--- a/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
+++ b/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <!-- Spike: desktop (Skia) head only. Add net10.0-windows10.0.26100 on a
-         Windows machine to target Windows App SDK / real WinUI 3. -->
+    <!-- The Uno Skia desktop head builds everywhere. The Windows App SDK head
+         is the real WinUI 3 target, and can only be built on Windows — adding
+         it unconditionally would break restore and build on Linux/macOS. -->
     <TargetFrameworks>net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net10.0-windows10.0.26100</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -147,7 +147,7 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                         sp.Padding = value is null ? default : ParseThickness(value);
                         return;
                     case "Background":
-                        SetBrush(sp, FrameworkElement.BackgroundProperty, value);
+                        SetBrush(sp, Panel.BackgroundProperty, value);
                         return;
                 }
                 break;
@@ -168,7 +168,7 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                         g.Padding = value is null ? default : ParseThickness(value);
                         return;
                     case "Background":
-                        SetBrush(g, FrameworkElement.BackgroundProperty, value);
+                        SetBrush(g, Panel.BackgroundProperty, value);
                         return;
                 }
                 break;
@@ -188,7 +188,7 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                         SetBrush(b, Border.BorderBrushProperty, value);
                         return;
                     case "Background":
-                        SetBrush(b, FrameworkElement.BackgroundProperty, value);
+                        SetBrush(b, Border.BackgroundProperty, value);
                         return;
                 }
                 break;
@@ -266,7 +266,7 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                         SetBrush(btn, Control.ForegroundProperty, value);
                         return;
                     case "Background":
-                        SetBrush(btn, FrameworkElement.BackgroundProperty, value);
+                        SetBrush(btn, Control.BackgroundProperty, value);
                         return;
                 }
                 break;

--- a/docs/adr/ADR-027-native-winui-renderer.md
+++ b/docs/adr/ADR-027-native-winui-renderer.md
@@ -41,7 +41,8 @@ that everything a renderer needs is public. See
    (case-insensitive), which `HtmlSpec.VoidElements` would silently skip child-diffing for.
 3. **`Picea.Abies.WinUI` codes against the WinUI 3 API surface** (`Microsoft.UI.Xaml`) and is built with the
    Uno.Sdk so the same code runs on Windows App SDK (real WinUI 3) and, via Uno Platform's Skia heads, on
-   macOS/Linux/WebAssembly. It contains the `WinUIBackend` (control factory, string→native property parsing,
+   macOS/Linux/WebAssembly. Both heads are built in CI: `net10.0-desktop` on Linux and, guarded by
+   `IsOSPlatform('Windows')`, `net10.0-windows10.0.26100` on `windows-latest`. It contains the `WinUIBackend` (control factory, string→native property parsing,
    event wiring with `IsApplying` echo suppression) and a one-line `Runtime.Run` bootstrap that marshals
    `Apply` to the `DispatcherQueue`.
 4. **Vocabulary and renderer are separate projects** so shared app code references only `Picea.Abies.Native`
@@ -61,10 +62,14 @@ that everything a renderer needs is public. See
 
 ### Negative
 
-- **Only the Uno Skia head (`net10.0-desktop`) is validated.** `Picea.Abies.WinUI` codes against the
-  WinUI 3 API surface but has not yet been compiled or run against Windows App SDK; the
-  `net10.0-windows10.0.26100` head and a `windows-latest` CI job are the immediate follow-up. Until
-  then this is an Uno Skia renderer with a WinUI-shaped API, and should be described that way.
+- The vocabulary is deliberately small and string-encodes typed properties, so the backend parses
+  at apply time rather than the compiler checking at call sites.
+- Maintaining two heads means tooling run on one can produce code that breaks the other. This is not
+  hypothetical: `dotnet format`'s IDE0002 rewrote `Panel.BackgroundProperty` to
+  `FrameworkElement.BackgroundProperty` — correct for Uno, nonexistent in WinUI 3 — before the code
+  was first committed. Access through the derived type is portable, and a project-level
+  `.editorconfig` disables IDE0002 to keep it that way. The `windows-latest` CI job is what makes
+  this class of divergence visible.
 - `View` is per-platform: a native program must delegate to a shared program class (boilerplate) until the
   `Program` contract is split into Core + View interfaces.
 - The native vocabulary starts small (10 controls) and string-encodes typed properties; breadth, styling,
@@ -100,7 +105,9 @@ objects, which `Apply` already provides in-process.
 
 Landed on `main` as four PRs: the platform-neutral vocabulary and interpreter (#321), the WinUI
 backend and Uno desktop head (#322), the native Counter sample (#323), and this record (#324).
-Remaining work is tracked in
+The Windows App SDK head and its `windows-latest` CI job followed in #326 — the first time the real
+WinUI 3 target was compiled, which is what allows this ADR to describe the renderer as WinUI rather
+than Uno Skia. Remaining work is tracked in
 [the production-readiness plan](../investigations/winui-native-production-readiness.md).
 
 ## Related Decisions

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -177,20 +177,42 @@ The 2,893-line branch exceeds the PR size limit, so split it:
 **Exit:** `main` builds and tests green; native tests run in CI; no new required-check
 failures.
 
-### Phase 1 — Make the name true (~1 week)
+### Phase 1 — Make the name true
 
-Goal: real WinUI 3 on Windows.
+**Compilation: done (#326).** `Picea.Abies.WinUI` and the sample now resolve
+`net10.0-windows10.0.26100` under an `IsOSPlatform('Windows')` guard, and a
+`winui-windows` job on `windows-latest` builds both heads plus the native tests
+(~5 min). B2 is closed: the WinUI 3 target has been compiled and is now covered on
+every PR.
 
-- Add `net10.0-windows10.0.26100` to `Picea.Abies.WinUI` and the sample (B2).
-- Add a `windows-latest` CI job building both heads. This is the only new required
-  platform in CI; keep it a separate job so Linux jobs stay fast.
-- Run the sample on Windows; fix whatever the Windows App SDK surfaces (expect
-  divergence in `RenderTargetBitmap`, `Colors`, and theme resources).
-- Wire the `ABIES_SNAPSHOT` PNG path into CI as a smoke check on both heads.
+That job earned its place immediately by catching a real divergence — see
+"Tooling divergence" below.
+
+**Still open in this phase:**
+
+- Run the sample *on* Windows and wire the `ABIES_SNAPSHOT` PNG path into CI as a
+  smoke check for both heads. Compilation is verified; **runtime behaviour on
+  Windows App SDK is not.** Expect further divergence in `RenderTargetBitmap`,
+  `Colors`, and theme resources.
 - Address N3: error boundary around `Apply`, honour `TryEnqueue`'s return, surface
-  dispatch failures through the existing `subscriptionFaulted`-style callback.
+  dispatch failures.
 
-**Exit:** ADR-027's headline claim is demonstrably true on Windows and verified in CI.
+**Exit:** the sample is shown running on real WinUI 3, not merely compiling.
+
+#### Tooling divergence (new finding)
+
+`dotnet format` runs against whichever head the tooling loads — on Linux always Uno —
+so it can emit code that does not compile for the other head. IDE0002 rewrote
+`Panel.BackgroundProperty` to `FrameworkElement.BackgroundProperty`: correct for Uno,
+which declares Background on `FrameworkElement`, and nonexistent in WinUI 3, which
+declares it on `Panel`/`Border`/`Control`. It did this *before the code was first
+committed*, so the defect shipped in #322 and sat undetected until Windows CI existed.
+
+Access through the derived type is valid on both heads and is therefore the portable
+spelling; `Picea.Abies.WinUI/.editorconfig` disables IDE0002 to stop the rewrite.
+Only Background diverges today — BorderBrush and Foreground agree — but the general
+lesson stands: **a Linux-only lint cannot be trusted to keep multi-head code portable,
+and the Windows job is the thing that makes it visible.**
 
 ### Phase 2 — API shape freeze (~1 week)
 
@@ -236,12 +258,15 @@ Everything here is breaking, so it must precede packaging.
 Phase 0 is done: B1, B3, D3, N1 and N2 are fixed and covered by tests, and the CI
 cost of the Uno toolchain is measured and cached rather than assumed.
 
-**Phase 1 is now the critical path.** B2 — no Windows App SDK head — is the only
-remaining blocker, and it is the one that decides whether ADR-027's headline claim
-is true. Note that `dotnet format` removed the explicit `Microsoft.UI.Xaml` and
-`Microsoft.UI.Xaml.Controls` usings from the backend as redundant under the Uno
-desktop head's implicit usings; **re-check those when the Windows head is added**,
-since its implicit-using set may differ.
+**B2 is closed (#326):** the Windows App SDK head compiles and is covered by CI on
+every PR, so ADR-027's headline claim now holds for compilation. The implicit-usings
+worry flagged here earlier turned out to be a non-issue — Uno's
+`Uno.Implicit.Namespaces.targets` declares `Microsoft.UI.Xaml` and friends with no TFM
+guard, so both heads agree. A different tooling divergence did bite, and is documented
+under Phase 1.
+
+**The remaining Phase 1 work is runtime, not compilation.** Nothing has yet *run* on
+Windows App SDK; the `ABIES_SNAPSHOT` smoke check is how to prove it.
 
 Do **not** ship packages before Phase 2: D1 (enum shadowing) and D2 (`Program`
 Core/View split) are both breaking, and shipping them post-1.0 costs far more than


### PR DESCRIPTION
Phase 1 of the [production-readiness plan](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md) — closing the gap between what ADR-027 is called and what has actually been compiled.

### What

`Picea.Abies.WinUI` and `Picea.Abies.Counter.Native` now resolve a second TFM, `net10.0-windows10.0.26100` (Windows App SDK / real WinUI 3), guarded by `IsOSPlatform('Windows')`:

```xml
<TargetFrameworks>net10.0-desktop</TargetFrameworks>
<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net10.0-windows10.0.26100</TargetFrameworks>
```

Plus a `winui-windows` job on `windows-latest` that builds **both heads** of both projects and runs the native tests.

### Why

ADR-027 is named for WinUI 3, but every build so far — local and CI — has been the Uno **Skia** head. The Windows App SDK target the renderer codes against had never been compiled, which the ADR records as its main open risk. Until this job goes green, the honest description is "an Uno Skia renderer with a WinUI-shaped API".

**The `IsOSPlatform` guard is load-bearing.** Linux and macOS cannot build a Windows target, and every existing CI job runs on `ubuntu-latest` against the whole solution — an unconditional TFM would break all of them. Verified locally that Linux still resolves `net10.0-desktop` alone:

```
$ dotnet msbuild Picea.Abies.WinUI/Picea.Abies.WinUI.csproj -getProperty:TargetFrameworks
net10.0-desktop
```

### A risk from the plan, now closed

The plan flagged that `dotnet format` had stripped the explicit `Microsoft.UI.Xaml` / `Microsoft.UI.Xaml.Controls` usings as redundant under the desktop head's implicit usings, and warned they might not be implicit on the Windows head. They are: Uno.Sdk's `Uno.Implicit.Namespaces.targets` declares them under a plain `ImplicitUsings` condition with no TFM guard, so both heads see the same set. No source change needed.

### Testing

- Linux: both projects build 0 warnings / 0 errors, and resolve to `net10.0-desktop` only — existing CI is unaffected.
- Workflow YAML parses; the new job is correctly gated on `detect-changes` and skipped for docs-only PRs.
- **The Windows head itself is verified by the new CI job in this PR** — it is the first time that target has ever been compiled, so this PR is where we find out. I'll iterate on whatever it surfaces.

### Note for branch protection

`WinUI (Windows App SDK)` is a new check. Like `build`, it isn't wired into `pr-validation-summary`'s `needs`; if you want it blocking, add it to the required checks in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)