### PR TITLE
feat(winui): Add a render smoke check and surface rendering faults

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -807,6 +807,81 @@ jobs:
       - name: Test Picea.Abies.Native.Tests
         run: dotnet test --project Picea.Abies.Native.Tests/Picea.Abies.Native.Tests.csproj
 
+      # Proves the Windows App SDK head actually rasterizes controls, not just
+      # that it compiles. Exits non-zero on a blank or empty render target.
+      - name: Render smoke check (Windows App SDK head)
+        shell: pwsh
+        timeout-minutes: 6
+        env:
+          ABIES_SNAPSHOT: ${{ github.workspace }}\snapshot-winappsdk.png
+          ABIES_SNAPSHOT_DELAY_MS: '8000'
+        run: |
+          dotnet run --project Picea.Abies.Counter.Native/Picea.Abies.Counter.Native.csproj `
+            -c Release -f net10.0-windows10.0.26100
+          if (-not (Test-Path $env:ABIES_SNAPSHOT)) { throw "No snapshot produced at $env:ABIES_SNAPSHOT" }
+          Get-Item $env:ABIES_SNAPSHOT | Select-Object Name, Length
+
+      - name: Upload Windows render snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-render-snapshot-winappsdk
+          path: snapshot-winappsdk.png
+          if-no-files-found: ignore
+
+  # Proves the Uno Skia desktop head rasterizes controls under a virtual
+  # display. Kept out of the required `build` job so a GUI hiccup cannot block
+  # merges on its own.
+  native-render-smoke:
+    name: Native Render Smoke (Skia)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event.pull_request.draft == false && needs.detect-changes.outputs.docs_only == 'false'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET (from global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Install virtual display
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libfontconfig1
+
+      - name: Render smoke check (Skia desktop head)
+        timeout-minutes: 8
+        env:
+          ABIES_SNAPSHOT: ${{ github.workspace }}/snapshot-skia.png
+          ABIES_SNAPSHOT_DELAY_MS: '8000'
+        run: |
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            dotnet run --project Picea.Abies.Counter.Native/Picea.Abies.Counter.Native.csproj \
+              -c Release -f net10.0-desktop
+          test -s "$ABIES_SNAPSHOT" || { echo "❌ No snapshot produced at $ABIES_SNAPSHOT"; exit 1; }
+          ls -l "$ABIES_SNAPSHOT"
+
+      - name: Upload Skia render snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-render-snapshot-skia
+          path: snapshot-skia.png
+          if-no-files-found: ignore
+
   # Check for TODO/FIXME without issues
   check-todos:
     name: Check TODOs

--- a/Picea.Abies.Counter.Native/App.xaml.cs
+++ b/Picea.Abies.Counter.Native/App.xaml.cs
@@ -27,16 +27,34 @@ public partial class App : Application
         // window's lifetime; the returned Task only completes on fatal error.
         _ = RunAsync(rootHost, MainWindow);
 
-        // Headless visual check: ABIES_SNAPSHOT=<path.png> renders the tree
+        // Headless visual check: ABIES_SNAPSHOT=<path.png> rasterizes the tree
         // to a PNG shortly after startup and exits — no OS screen-capture
-        // permission involved.
+        // permission involved. Used in CI to prove the renderer actually draws
+        // on each head, rather than merely compiling.
         if (Environment.GetEnvironmentVariable("ABIES_SNAPSHOT") is { Length: > 0 } snapshotPath)
             _ = SnapshotAndExitAsync(rootHost, snapshotPath);
     }
 
     private static async Task SnapshotAndExitAsync(FrameworkElement root, string path)
     {
-        await Task.Delay(4000);
+        // Give the runtime time to start and lay out. Configurable because a
+        // cold CI runner is much slower than a warm desktop.
+        var delay = Environment.GetEnvironmentVariable("ABIES_SNAPSHOT_DELAY_MS") is { Length: > 0 } raw
+            && int.TryParse(raw, out var parsed)
+                ? parsed
+                : 4000;
+        await Task.Delay(delay);
+
+        // Watchdog: without it, a head that never reaches the render callback
+        // leaves the process hanging until the CI job times out, with no
+        // indication of what went wrong.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(60));
+            Console.Error.WriteLine("Snapshot watchdog: render did not complete within 60s of the delay elapsing.");
+            Environment.Exit(2);
+        });
+
         root.DispatcherQueue.TryEnqueue(async void () =>
         {
             try
@@ -45,13 +63,33 @@ public partial class App : Application
                 await bitmap.RenderAsync(root);
                 var pixels = (await bitmap.GetPixelsAsync()).ToArray();
 
+                if (bitmap.PixelWidth <= 0 || bitmap.PixelHeight <= 0 || pixels.Length == 0)
+                {
+                    Console.Error.WriteLine(
+                        $"Snapshot failed: empty render target ({bitmap.PixelWidth}x{bitmap.PixelHeight}, {pixels.Length} bytes).");
+                    Environment.Exit(1);
+                }
+
+                // A uniform image means the window came up but nothing drew —
+                // which is exactly the failure a "did it build?" check misses.
+                if (IsUniform(pixels))
+                {
+                    Console.Error.WriteLine(
+                        $"Snapshot failed: {bitmap.PixelWidth}x{bitmap.PixelHeight} image is a single flat colour, so no controls rendered.");
+                    Environment.Exit(1);
+                }
+
                 var info = new SKImageInfo(bitmap.PixelWidth, bitmap.PixelHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
                 using var skBitmap = new SKBitmap(info);
                 Marshal.Copy(pixels, 0, skBitmap.GetPixels(), pixels.Length);
                 using var image = SKImage.FromBitmap(skBitmap);
                 using var data = image.Encode(SKEncodedImageFormat.Png, 100);
-                await using var stream = File.OpenWrite(path);
-                data.SaveTo(stream);
+                await using (var stream = File.OpenWrite(path))
+                {
+                    data.SaveTo(stream);
+                }
+
+                Console.Out.WriteLine($"Snapshot written: {path} ({bitmap.PixelWidth}x{bitmap.PixelHeight})");
                 Environment.Exit(0);
             }
             catch (Exception ex)
@@ -60,6 +98,20 @@ public partial class App : Application
                 Environment.Exit(1);
             }
         });
+    }
+
+    /// <summary>True when every pixel is identical — i.e. nothing was drawn.</summary>
+    private static bool IsUniform(byte[] bgra)
+    {
+        for (var i = 4; i + 3 < bgra.Length; i += 4)
+        {
+            if (bgra[i] != bgra[0] || bgra[i + 1] != bgra[1] ||
+                bgra[i + 2] != bgra[2] || bgra[i + 3] != bgra[3])
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static async Task RunAsync(Grid rootHost, Window window)

--- a/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
+++ b/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
@@ -142,6 +142,100 @@ public class PatchInterpreterTests
     public record Echo(string Text) : Message;
 
     // =========================================================================
+    // Dispatch faults
+    // =========================================================================
+    // Dispatch is fire-and-forget, so without an explicit hook a failing update
+    // is invisible: the UI just stops responding.
+
+    private static Element ClickableButton() =>
+        new("b1", "Button", [new Handler("Click", "c1", new Ping(), "h1")]);
+
+    [Test]
+    public async Task DispatchFaultingAsynchronously_IsReported()
+    {
+        var (interpreter, _) = Create();
+        interpreter.Apply(Operations.Diff(null, ClickableButton()));
+
+        Exception? reported = null;
+        interpreter.Faulted = ex => reported = ex;
+        interpreter.Dispatch = async _ =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("update blew up");
+        };
+
+        interpreter.OnNativeEvent("b1", "Click", null);
+        await Task.Delay(50);
+
+        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
+        await Assert.That(reported!.Message).IsEqualTo("update blew up");
+    }
+
+    [Test]
+    public async Task DispatchThrowingSynchronously_IsReported()
+    {
+        var (interpreter, _) = Create();
+        interpreter.Apply(Operations.Diff(null, ClickableButton()));
+
+        Exception? reported = null;
+        interpreter.Faulted = ex => reported = ex;
+        interpreter.Dispatch = _ => throw new InvalidOperationException("threw before awaiting");
+
+        interpreter.OnNativeEvent("b1", "Click", null);
+
+        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task SuccessfulDispatch_ReportsNothing()
+    {
+        var (interpreter, _) = Create();
+        interpreter.Apply(Operations.Diff(null, ClickableButton()));
+
+        Exception? reported = null;
+        interpreter.Faulted = ex => reported = ex;
+        interpreter.Dispatch = _ => ValueTask.CompletedTask;
+
+        interpreter.OnNativeEvent("b1", "Click", null);
+        await Task.Delay(50);
+
+        await Assert.That(reported).IsNull();
+    }
+
+    /// <summary>
+    /// A throwing fault handler must not escalate — inside the async observer
+    /// that would be an unhandled exception on the UI thread.
+    /// </summary>
+    [Test]
+    public async Task FaultHandlerThatThrows_DoesNotEscalate()
+    {
+        var (interpreter, _) = Create();
+        interpreter.Apply(Operations.Diff(null, ClickableButton()));
+
+        interpreter.Faulted = _ => throw new InvalidOperationException("handler is broken too");
+        interpreter.Dispatch = _ => throw new InvalidOperationException("dispatch failed");
+
+        interpreter.OnNativeEvent("b1", "Click", null);
+        await Task.Delay(50);
+
+        // Reaching here without an unhandled exception is the assertion.
+        await Assert.That(interpreter.ControlCount).IsEqualTo(1);
+    }
+
+    /// <summary>Dispatch failures must not leave IsApplying stuck on.</summary>
+    [Test]
+    public async Task ApplyThatThrows_ResetsIsApplying()
+    {
+        var (interpreter, _) = Create();
+        var parent = new Element("p", "StackPanel", []);
+        interpreter.Apply(Operations.Diff(null, parent));
+
+        await Assert.That(() => interpreter.Apply([new AddText(parent, new Text("t", "boom"))]))
+            .Throws<NotSupportedException>();
+        await Assert.That(interpreter.IsApplying).IsFalse();
+    }
+
+    // =========================================================================
     // Children: keyed reorder, removal
     // =========================================================================
 

--- a/Picea.Abies.Native/Rendering/PatchInterpreter.cs
+++ b/Picea.Abies.Native/Rendering/PatchInterpreter.cs
@@ -40,6 +40,15 @@ public sealed class PatchInterpreter<T> : INativeEventSink where T : class
     /// </summary>
     public Func<Message, ValueTask>? Dispatch { get; set; }
 
+    /// <summary>
+    /// Receives faults that would otherwise be lost. Dispatch is
+    /// fire-and-forget — a native event hands a message to the runtime and
+    /// returns, matching the browser renderer — so without this hook a failing
+    /// update or command interpreter fails silently and the UI simply stops
+    /// responding. Set during bootstrap, before the first event can fire.
+    /// </summary>
+    public Action<Exception>? Faulted { get; set; }
+
     /// <inheritdoc />
     public bool IsApplying { get; private set; }
 
@@ -75,7 +84,57 @@ public sealed class PatchInterpreter<T> : INativeEventSink where T : class
 
         var dispatch = Dispatch
             ?? throw new InvalidOperationException("PatchInterpreter.Dispatch is not wired to a runtime.");
-        _ = dispatch(message);
+
+        ValueTask pending;
+        try
+        {
+            pending = dispatch(message);
+        }
+        catch (Exception ex)
+        {
+            // Dispatch threw before returning a task (synchronous failure).
+            Report(ex);
+            return;
+        }
+
+        if (pending.IsCompletedSuccessfully)
+            return;
+
+        Observe(pending);
+    }
+
+    /// <summary>
+    /// Awaits a dispatch that did not complete synchronously, so its failure
+    /// reaches <see cref="Faulted"/> rather than becoming an unobserved
+    /// exception. Never throws: the whole body is guarded.
+    /// </summary>
+    private async void Observe(ValueTask pending)
+    {
+        try
+        {
+            await pending;
+        }
+        catch (Exception ex)
+        {
+            Report(ex);
+        }
+    }
+
+    /// <summary>Reports a fault, never letting the reporter itself throw.</summary>
+    private void Report(Exception exception)
+    {
+        var faulted = Faulted;
+        if (faulted is null)
+            return;
+        try
+        {
+            faulted(exception);
+        }
+        catch
+        {
+            // A throwing fault handler must not escalate into the caller —
+            // for Observe that would be an unhandled exception on the UI thread.
+        }
     }
 
     private void ApplyPatch(Patch patch)

--- a/Picea.Abies.WinUI/Runtime.cs
+++ b/Picea.Abies.WinUI/Runtime.cs
@@ -28,17 +28,28 @@ public static class Runtime
     /// <param name="argument">The program's initialization argument.</param>
     /// <param name="interpreter">Command interpreter for the program's effects; defaults to a no-op.</param>
     /// <param name="subscriptionFaulted">Callback for subscription failures.</param>
+    /// <param name="renderFaulted">
+    /// Receives rendering and dispatch failures: a patch batch that threw, a
+    /// batch dropped because the dispatcher queue is shutting down, or a
+    /// message dispatch that faulted. Defaults to writing to standard error —
+    /// these failures are otherwise invisible, and the symptom is a window that
+    /// silently stops updating.
+    /// </param>
     public static async Task<Runtime<TProgram, TModel, TArgument>> Run<TProgram, TModel, TArgument>(
         Panel rootHost,
         Window window,
         TArgument argument = default!,
         Interpreter<Command, Message>? interpreter = null,
-        Action<SubscriptionFault>? subscriptionFaulted = null)
+        Action<SubscriptionFault>? subscriptionFaulted = null,
+        Action<Exception>? renderFaulted = null)
         where TProgram : Program<TModel, TArgument>
     {
         var dispatcherQueue = rootHost.DispatcherQueue;
         var backend = new WinUIBackend(rootHost);
         var patchInterpreter = new PatchInterpreter<FrameworkElement>(backend);
+
+        void Report(Exception exception) =>
+            (renderFaulted ?? DefaultRenderFaulted).Invoke(exception);
 
         Runtime<TProgram, TModel, TArgument>? runtime = null;
         patchInterpreter.Dispatch = async message =>
@@ -46,21 +57,47 @@ public static class Runtime
             if (runtime is not null)
                 await runtime.Dispatch(message);
         };
+        patchInterpreter.Faulted = Report;
+
+        // A patch batch that throws leaves the control tree out of sync with
+        // the model, but letting it escape would take down the UI thread with
+        // no diagnostic at all. Report and keep the window alive.
+        void ApplyGuarded(IReadOnlyList<Patch> patches)
+        {
+            try
+            {
+                patchInterpreter.Apply(patches);
+            }
+            catch (Exception ex)
+            {
+                Report(new NativeRenderException(
+                    "Applying a patch batch failed; the native view no longer reflects the model.", ex));
+            }
+        }
 
         void Apply(IReadOnlyList<Patch> patches)
         {
             if (dispatcherQueue.HasThreadAccess)
-                patchInterpreter.Apply(patches);
-            else
-                dispatcherQueue.TryEnqueue(() => patchInterpreter.Apply(patches));
+            {
+                ApplyGuarded(patches);
+                return;
+            }
+
+            // TryEnqueue returns false once the queue is shutting down. Ignoring
+            // it silently drops the batch and desyncs the view.
+            if (!dispatcherQueue.TryEnqueue(() => ApplyGuarded(patches)))
+            {
+                Report(new NativeRenderException(
+                    $"Dropped a batch of {patches.Count} patch(es): the dispatcher queue is shutting down."));
+            }
         }
 
         void TitleChanged(string title)
         {
             if (dispatcherQueue.HasThreadAccess)
                 window.Title = title;
-            else
-                dispatcherQueue.TryEnqueue(() => window.Title = title);
+            else if (!dispatcherQueue.TryEnqueue(() => window.Title = title))
+                Report(new NativeRenderException("Dropped a title update: the dispatcher queue is shutting down."));
         }
 
         runtime = await Runtime<TProgram, TModel, TArgument>.Start(
@@ -76,4 +113,21 @@ public static class Runtime
 
     private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>
         ValueTask.FromResult(Result<Message[], PipelineError>.Ok([]));
+
+    private static void DefaultRenderFaulted(Exception exception) =>
+        Console.Error.WriteLine($"Abies native render fault: {exception}");
+}
+
+/// <summary>
+/// A failure in the native rendering path: applying a patch batch threw, or a
+/// batch could not be delivered to the UI thread.
+/// </summary>
+public sealed class NativeRenderException : Exception
+{
+    /// <param name="message">Description of the failure.</param>
+    public NativeRenderException(string message) : base(message) { }
+
+    /// <param name="message">Description of the failure.</param>
+    /// <param name="innerException">The underlying failure.</param>
+    public NativeRenderException(string message, Exception innerException) : base(message, innerException) { }
 }


### PR DESCRIPTION
Completes Phase 1 of the [production-readiness plan](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md): proving the renderer *draws* on both heads, and making failures visible.

### What

**1. Error boundary (plan item N3)**

The native render path had three ways to fail without a trace:

| Failure | Before | Now |
| --- | --- | --- |
| Exception inside a patch batch | Unhandled on the UI thread → app dies | Caught, reported as `NativeRenderException` |
| `TryEnqueue` returns `false` (queue shutting down) | Batch silently dropped, view desyncs | Reported |
| Dispatch faults (`_ = dispatch(msg)`) | Swallowed; UI just stops responding | Observed and reported |

`PatchInterpreter` gains a `Faulted` hook and now observes the dispatch task rather than discarding it, catching both synchronous throws and faulted tasks. The reporter is itself guarded — inside the async observer a throwing handler would become an unhandled exception on the UI thread. `Runtime.Run` takes an optional `renderFaulted`; the default writes to standard error, so nothing is silent purely by omission.

**2. Render smoke check**

`#326` proved the Windows head *compiles*. Nothing had ever *run*. `ABIES_SNAPSHOT` now:

- fails on an empty render target,
- **fails on a uniform image** — a window that comes up with nothing drawn is precisely the failure a build-only check misses,
- takes a configurable delay (`ABIES_SNAPSHOT_DELAY_MS`) for cold CI runners,
- has a watchdog that exits non-zero instead of hanging until the job times out.

CI runs it on **both heads**: Windows App SDK inside the existing `winui-windows` job, and the Skia head under Xvfb in a new `native-render-smoke` job. Both upload the PNG as an artifact, so you can look at what rendered.

### Why

Phase 1's goal was "make the name true". Compilation was the first half; this is the second. A renderer that builds and then draws nothing is still broken, and until now nothing in CI could tell the difference.

`native-render-smoke` is deliberately **not** folded into the required `build` job — a GUI-dependent check under a virtual display is the kind of thing that flakes, and it shouldn't be able to block merges on its own.

### Testing

- **24 native tests** pass, including five new ones covering the fault paths (async fault, synchronous throw, success reports nothing, throwing fault handler doesn't escalate, `IsApplying` resets after a throw).
- The three dispatch-fault tests were **confirmed to fail against the previous fire-and-forget code**, so they genuinely pin the behaviour.
- Uno head builds 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean across all three projects.
- **The smoke checks themselves are verified by this PR's CI** — I have no display locally, so their first real run is here. I'll iterate on whatever they surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)