### PR TITLE
refactor(native)!: Rename value enums so they stop shadowing the factories

### DIFF
--- a/Picea.Abies.Counter.Native/NativeCounter.cs
+++ b/Picea.Abies.Counter.Native/NativeCounter.cs
@@ -6,21 +6,14 @@
 // supplies only a native-vocabulary View. This is the whole point of the
 // spike: one pure program, three renderers (browser DOM, server, native
 // WinUI controls).
-//
-// The enum aliases work around a DSL friction: Properties method names
-// (Orientation, FontWeight) shadow the identically-named enums when
-// imported via `using static`. Candidate refinement noted in
-// docs/research/native-winui-mvu.md.
 // =============================================================================
 
 using Picea.Abies.DOM;
+using Picea.Abies.Native;
 using Picea.Abies.Subscriptions;
 using static Picea.Abies.Native.Elements;
 using static Picea.Abies.Native.Events;
 using static Picea.Abies.Native.Properties;
-using NativeAlignment = Picea.Abies.Native.Alignment;
-using NativeFontWeight = Picea.Abies.Native.FontWeight;
-using NativeOrientation = Picea.Abies.Native.Orientation;
 
 namespace Picea.Abies.Counter.Native;
 
@@ -38,17 +31,17 @@ public sealed class NativeCounterProgram : Program<CounterModel, Unit>
 
     public static Document View(CounterModel model) =>
         new("Abies Counter",
-            StackPanel([Spacing(16), HorizontalAlignment(NativeAlignment.Center), VerticalAlignment(NativeAlignment.Center)],
+            StackPanel([Spacing(16), HorizontalAlignment(Alignment.Center), VerticalAlignment(Alignment.Center)],
             [
-                TextBlock([FontSize(28), FontWeight(NativeFontWeight.Bold), HorizontalAlignment(NativeAlignment.Center)],
+                TextBlock([FontSize(28), FontWeight(TextWeight.Bold), HorizontalAlignment(Alignment.Center)],
                     "Abies Counter"),
-                StackPanel([Orientation(NativeOrientation.Horizontal), Spacing(12), HorizontalAlignment(NativeAlignment.Center)],
+                StackPanel([Orientation(StackOrientation.Horizontal), Spacing(12), HorizontalAlignment(Alignment.Center)],
                 [
                     Button([OnClick(new Decrement()), Width(48)], "−"),
-                    TextBlock([FontSize(24), Width(64), VerticalAlignment(NativeAlignment.Center), HorizontalAlignment(NativeAlignment.Center)],
+                    TextBlock([FontSize(24), Width(64), VerticalAlignment(Alignment.Center), HorizontalAlignment(Alignment.Center)],
                         model.Count.ToString()),
                     Button([OnClick(new Increment()), Width(48)], "+"),
                 ]),
-                Button([OnClick(new Reset()), HorizontalAlignment(NativeAlignment.Center)], "Reset"),
+                Button([OnClick(new Reset()), HorizontalAlignment(Alignment.Center)], "Reset"),
             ]));
 }

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -19,8 +19,14 @@ using Praefixum;
 
 namespace Picea.Abies.Native;
 
-/// <summary>Layout orientation for stack-like panels.</summary>
-public enum Orientation { Vertical, Horizontal }
+/// <summary>
+/// Layout orientation for stack-like panels. Named <c>StackOrientation</c>
+/// rather than <c>Orientation</c> so it does not collide with the
+/// <see cref="Properties.Orientation"/> factory when both this namespace and
+/// <c>Properties</c> are imported with <c>using static</c> — the method would
+/// otherwise hide the type and force an alias at every use site.
+/// </summary>
+public enum StackOrientation { Vertical, Horizontal }
 
 /// <summary>
 /// Platform-neutral alignment. The backend maps Start/End onto
@@ -28,8 +34,12 @@ public enum Orientation { Vertical, Horizontal }
 /// </summary>
 public enum Alignment { Start, Center, End, Stretch }
 
-/// <summary>Font weight for text-bearing controls.</summary>
-public enum FontWeight { Normal, SemiBold, Bold }
+/// <summary>
+/// Font weight for text-bearing controls. Named <c>TextWeight</c> to avoid
+/// colliding with the <see cref="Properties.FontWeight"/> factory; see
+/// <see cref="StackOrientation"/>.
+/// </summary>
+public enum TextWeight { Normal, SemiBold, Bold }
 
 /// <summary>
 /// Factory functions for native control property attributes.
@@ -64,7 +74,7 @@ public static class Properties
     // Layout
     // =========================================================================
 
-    public static DOM.Attribute Orientation(Orientation value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+    public static DOM.Attribute Orientation(StackOrientation value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Orientation", value.ToString(), id);
 
     public static DOM.Attribute Spacing(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
@@ -121,7 +131,7 @@ public static class Properties
     public static DOM.Attribute FontSize(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("FontSize", Num(value), id);
 
-    public static DOM.Attribute FontWeight(FontWeight value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+    public static DOM.Attribute FontWeight(TextWeight value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("FontWeight", value.ToString(), id);
 
     /// <summary>Foreground color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -94,9 +94,15 @@ must be made deliberate: SDK pin, NuGet caching, and an explicit test step.
 
 **D1 — `Properties` method names shadow the identically-named enums** under
 `using static`, forcing `NativeOrientation` / `NativeFontWeight` / `NativeAlignment`
-aliases at every use site. This is visible in the sample and is the first thing a
-user will hit. Rename one side (suggestion: enums move to a `Values` static class,
-or become `OrientationValue`) **before** the package ships.
+aliases at every use site.
+
+**Fixed.** The enums are now `StackOrientation` and `TextWeight`, so the factories
+(`Orientation(...)`, `FontWeight(...)`) keep their WinUI-faithful names and nothing is
+hidden. Only those two ever collided — `Alignment` is fine, because the factories are
+`HorizontalAlignment`/`VerticalAlignment`, which is why the sample's `NativeAlignment`
+alias was never actually needed. The sample now reads
+`Orientation(StackOrientation.Horizontal)` with no aliases at all, which is the proof
+the friction is gone.
 
 **D2 — `Program` contract is not split into Core + View.** Every native program
 must hand-delegate `Initialize`/`Transition`/`Decide`/`IsTerminal`/`Subscriptions`
@@ -235,8 +241,8 @@ and the Windows job is the thing that makes it visible.**
 
 Everything here is breaking, so it must precede packaging.
 
-- **D1**: resolve the `Properties`-vs-enum shadowing. Delete the alias workaround
-  from the sample — the sample is the proof the fix worked.
+- **D1 ✅ done**: enums renamed to `StackOrientation` / `TextWeight`; all three alias
+  workarounds deleted from the sample.
 - **D2**: split `Program` into Core + View interfaces; remove native delegation
   boilerplate. This touches the core, so it needs its own ADR and a compatibility
   review against browser/server programs.

--- a/docs/research/native-winui-mvu.md
+++ b/docs/research/native-winui-mvu.md
@@ -138,15 +138,16 @@ The spike was landed with three fixes, all covered by new tests:
   controlled-input strategy is future work).
 - Praefixum ids are per call site: elements created in loops must set `Properties.Id`/`Properties.Key`
   (same rule as the HTML DSL).
-- DSL friction: `Properties` method names (`Orientation`, `FontWeight`) shadow the identically-named enums
-  under `using static`, forcing aliases at use sites — rename either side before packaging.
+- ~~DSL friction: `Properties` method names shadow the identically-named enums under `using static`~~ —
+  fixed: the enums are now `StackOrientation` and `TextWeight`, so no aliases are needed.
+  (`Alignment` never collided; the factories are `HorizontalAlignment`/`VerticalAlignment`.)
 - Fire-and-forget dispatch from native events (matches browser behavior); dispatch failures are dropped.
 
 **Roadmap**
 
 1. **Phase 2 — vocabulary & ergonomics**: broaden controls (ItemsView, NavigationView, ContentDialog),
    element-content `Button`/`ContentControl` children, styling/theming story (map to XAML theme resources
-   rather than reinventing), fix the enum/method naming collision, Roslyn analyzer (per ADR-021) for the
+   rather than reinventing), Roslyn analyzer (per ADR-021) for the
    reserved-void-tag and Element-only-trees rules, split the `Program` contract into Core + View interfaces
    to remove native-program delegation boilerplate.
 2. **Phase 3 — scale & platform**: virtualized lists via an `ItemsRepeater` escape hatch (Reactor's


### PR DESCRIPTION
Phase 2 item **D1** from the [production-readiness plan](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md).

### What

`Picea.Abies.Native.Orientation` → **`StackOrientation`**, `FontWeight` → **`TextWeight`**.

**⚠️ Breaking change** to `Picea.Abies.Native`'s public API. Nothing is published yet, so it costs nothing today and would be expensive after Phase 4 packaging — which is exactly why the plan puts the API freeze before packaging.

### Why

`Properties.Orientation(...)` and `Properties.FontWeight(...)` hid the identically-named enums when both were imported with `using static`, forcing an alias at every call site:

```csharp
using NativeOrientation = Picea.Abies.Native.Orientation;
...
StackPanel([Orientation(NativeOrientation.Horizontal), Spacing(12)], ...)
```

This was the first thing any user would hit, and it was visible in the one sample we ship.

I renamed the **enums** rather than the factories deliberately: the factory names (`Orientation`, `FontWeight`) match the WinUI properties they set, which is what makes the vocabulary guessable from WinUI knowledge. Sacrificing that to fix a collision would trade a small annoyance for a permanent one.

**Only two enums ever collided.** `Alignment` did not — the factories are `HorizontalAlignment`/`VerticalAlignment` — so the sample's `NativeAlignment` alias was never actually necessary. I verified this by deleting all three aliases and compiling.

### The proof

The sample now reads with no aliases at all:

```csharp
StackPanel([Spacing(16), HorizontalAlignment(Alignment.Center), VerticalAlignment(Alignment.Center)],
[
    TextBlock([FontSize(28), FontWeight(TextWeight.Bold), HorizontalAlignment(Alignment.Center)], "Abies Counter"),
    StackPanel([Orientation(StackOrientation.Horizontal), Spacing(12), HorizontalAlignment(Alignment.Center)],
    [ ... ]),
]);
```

The sample picks up a plain `using Picea.Abies.Native;`, which the aliases had been standing in for.

### Testing

- Sample builds 0 warnings / 0 errors with every alias removed — that build *is* the regression test for this change.
- 24 native tests pass.
- `dotnet format --verify-no-changes` clean on both projects.
- Research doc and plan updated; the "DSL friction" limitation is struck out rather than deleted, so the record shows it was resolved rather than forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)