### PR TITLE
feat(core): Split the Program contract into Core and View

### DIFF
--- a/Picea.Abies.Counter.Native/App.xaml.cs
+++ b/Picea.Abies.Counter.Native/App.xaml.cs
@@ -118,7 +118,9 @@ public partial class App : Application
     {
         try
         {
-            await WinUI.Runtime.Run<NativeCounterProgram, CounterModel, Unit>(
+            // Shared core + native view. Nothing about CounterProgram is
+            // redeclared here — it is the same class the WASM and server hosts use.
+            await WinUI.Runtime.RunWithView<CounterProgram, NativeCounterView, CounterModel, Unit>(
                 rootHost, window, Unit.Value);
         }
         catch (Exception ex)

--- a/Picea.Abies.Counter.Native/NativeCounter.cs
+++ b/Picea.Abies.Counter.Native/NativeCounter.cs
@@ -1,34 +1,27 @@
 // =============================================================================
-// NativeCounterProgram — Shared Model/Update, Native View
+// NativeCounterView — Native View over the Shared Counter Program
 // =============================================================================
-// Delegates Initialize/Transition/Decide/IsTerminal/Subscriptions to the
-// existing CounterProgram (shared with the WASM and server hosts) and
-// supplies only a native-vocabulary View. This is the whole point of the
-// spike: one pure program, three renderers (browser DOM, server, native
-// WinUI controls).
+// This file is the whole native app: a View, and nothing else. Model, update,
+// decisions, termination and subscriptions all come from the existing
+// CounterProgram, shared verbatim with the WASM and server hosts.
+//
+// The pairing happens at the bootstrap call site via
+// WithView<CounterProgram, NativeCounterView, ...> — see App.xaml.cs. Before
+// the Program contract was split into ProgramCore + ProgramView, this class
+// also had to hand-forward five members to CounterProgram, because C# cannot
+// inherit static abstract implementations.
 // =============================================================================
 
 using Picea.Abies.DOM;
 using Picea.Abies.Native;
-using Picea.Abies.Subscriptions;
 using static Picea.Abies.Native.Elements;
 using static Picea.Abies.Native.Events;
 using static Picea.Abies.Native.Properties;
 
 namespace Picea.Abies.Counter.Native;
 
-public sealed class NativeCounterProgram : Program<CounterModel, Unit>
+public sealed class NativeCounterView : ProgramView<CounterModel>
 {
-    public static (CounterModel, Command) Initialize(Unit argument) => CounterProgram.Initialize(argument);
-
-    public static (CounterModel, Command) Transition(CounterModel model, Message message) => CounterProgram.Transition(model, message);
-
-    public static Result<Message[], Message> Decide(CounterModel model, Message command) => CounterProgram.Decide(model, command);
-
-    public static bool IsTerminal(CounterModel model) => CounterProgram.IsTerminal(model);
-
-    public static Subscription Subscriptions(CounterModel model) => CounterProgram.Subscriptions(model);
-
     public static Document View(CounterModel model) =>
         new("Abies Counter",
             StackPanel([Spacing(16), HorizontalAlignment(Alignment.Center), VerticalAlignment(Alignment.Center)],

--- a/Picea.Abies.Native.Tests/RuntimeIntegrationTests.cs
+++ b/Picea.Abies.Native.Tests/RuntimeIntegrationTests.cs
@@ -49,6 +49,104 @@ public sealed class NativeTestProgram : Program<CountModel, Unit>
     public static Subscription Subscriptions(CountModel _) => new Subscription.None();
 }
 
+// =============================================================================
+// Core/View split
+// =============================================================================
+// A shared core that mentions no DOM at all, and a native view over it. The
+// point is that SharedCountCore below could equally back a browser view — it is
+// reused verbatim, not reimplemented or hand-forwarded.
+
+public sealed class SharedCountCore : ProgramCore<CountModel, Unit>
+{
+    public static (CountModel, Command) Initialize(Unit _) => (new CountModel(0), Commands.None);
+
+    public static (CountModel, Command) Transition(CountModel model, Message message) =>
+        message switch
+        {
+            Increment => (model with { Count = model.Count + 1 }, Commands.None),
+            _ => (model, Commands.None)
+        };
+
+    public static Result<Message[], Message> Decide(CountModel _, Message command) =>
+        Result<Message[], Message>.Ok([command]);
+
+    public static bool IsTerminal(CountModel _) => false;
+
+    public static Subscription Subscriptions(CountModel _) => new Subscription.None();
+}
+
+public sealed class NativeCountView : ProgramView<CountModel>
+{
+    public static Document View(CountModel model) =>
+        new("Composed",
+            StackPanel([Spacing(4)],
+            [
+                TextBlock([FontSize(20)], model.Count.ToString()),
+                Button([OnClick(new Increment())], "+"),
+            ]));
+}
+
+public class CoreViewCompositionTests
+{
+    private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>
+        ValueTask.FromResult(Result<Message[], PipelineError>.Ok([]));
+
+    /// <summary>
+    /// WithView pairs a core and a view into a runnable program with no
+    /// per-app delegation, and the resulting program drives the full MVU loop.
+    /// </summary>
+    [Test]
+    public async Task WithView_ComposesSharedCoreAndNativeView()
+    {
+        var backend = new FakeBackend();
+        var interpreter = new PatchInterpreter<FakeControl>(backend);
+        string? title = null;
+
+        using var runtime = await Runtime<
+            WithView<SharedCountCore, NativeCountView, CountModel, Unit>,
+            CountModel, Unit>.Start(
+                interpreter.Apply, NoOpInterpreter, Unit.Value,
+                titleChanged: t => title = t);
+
+        var root = backend.Root!;
+        await Assert.That(title).IsEqualTo("Composed");
+        await Assert.That(root.Children[0].Props["Text"]).IsEqualTo("0");
+
+        // The core's Transition drives the update, the view redraws.
+        var result = await runtime.Dispatch(new Increment());
+        await Assert.That(result.IsOk).IsTrue();
+        await Assert.That(root.Children[0].Props["Text"]).IsEqualTo("1");
+    }
+
+    /// <summary>The same core renders through a different view.</summary>
+    [Test]
+    public async Task SameCore_DrivesADifferentView()
+    {
+        var backend = new FakeBackend();
+        var interpreter = new PatchInterpreter<FakeControl>(backend);
+
+        using var runtime = await Runtime<
+            WithView<SharedCountCore, AlternateCountView, CountModel, Unit>,
+            CountModel, Unit>.Start(
+                interpreter.Apply, NoOpInterpreter, Unit.Value);
+
+        // Same core, different shape on screen.
+        await Assert.That(backend.Root!.Tag).IsEqualTo("Border");
+        await Assert.That(backend.Root!.Children[0].Props["Text"]).IsEqualTo("count: 0");
+
+        await runtime.Dispatch(new Increment());
+        await Assert.That(backend.Root!.Children[0].Props["Text"]).IsEqualTo("count: 1");
+    }
+}
+
+public sealed class AlternateCountView : ProgramView<CountModel>
+{
+    public static Document View(CountModel model) =>
+        new("Alternate",
+            Border([Padding(8)],
+                TextBlock([FontSize(12)], $"count: {model.Count}")));
+}
+
 public class RuntimeIntegrationTests
 {
     private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>

--- a/Picea.Abies.WinUI/Runtime.cs
+++ b/Picea.Abies.WinUI/Runtime.cs
@@ -111,6 +111,34 @@ public static class Runtime
         return runtime;
     }
 
+    /// <summary>
+    /// Starts a program assembled from a shared core and a native view, which is
+    /// the normal shape for a native app: the model and update logic are shared
+    /// with the web and server hosts, and only <c>View</c> is platform-specific.
+    /// </summary>
+    /// <typeparam name="TCore">The shared program core.</typeparam>
+    /// <typeparam name="TView">The native view.</typeparam>
+    /// <typeparam name="TModel">The model type.</typeparam>
+    /// <typeparam name="TArgument">The initialization argument type.</typeparam>
+    /// <param name="rootHost">The panel that receives the root control.</param>
+    /// <param name="window">The hosting window; receives Document.Title updates.</param>
+    /// <param name="argument">The program's initialization argument.</param>
+    /// <param name="interpreter">Command interpreter for the program's effects; defaults to a no-op.</param>
+    /// <param name="subscriptionFaulted">Callback for subscription failures.</param>
+    /// <param name="renderFaulted">Callback for rendering and dispatch failures.</param>
+    public static Task<Runtime<WithView<TCore, TView, TModel, TArgument>, TModel, TArgument>>
+        RunWithView<TCore, TView, TModel, TArgument>(
+            Panel rootHost,
+            Window window,
+            TArgument argument = default!,
+            Interpreter<Command, Message>? interpreter = null,
+            Action<SubscriptionFault>? subscriptionFaulted = null,
+            Action<Exception>? renderFaulted = null)
+        where TCore : ProgramCore<TModel, TArgument>
+        where TView : ProgramView<TModel>
+        => Run<WithView<TCore, TView, TModel, TArgument>, TModel, TArgument>(
+            rootHost, window, argument, interpreter, subscriptionFaulted, renderFaulted);
+
     private static ValueTask<Result<Message[], PipelineError>> NoOpInterpreter(Command _) =>
         ValueTask.FromResult(Result<Message[], PipelineError>.Ok([]));
 

--- a/Picea.Abies/Program.cs
+++ b/Picea.Abies/Program.cs
@@ -4,15 +4,84 @@ using Picea.Abies.Subscriptions;
 
 namespace Picea.Abies;
 
-public interface Program<TModel, TArgument> : Decider<TModel, Message, Message, Command, Message, TArgument>
+/// <summary>
+/// Everything in a program except how it is drawn: initialization, transitions,
+/// command decisions, termination and subscriptions. This is the platform-free
+/// half — it mentions no DOM and no controls — so one core can be shared by
+/// views targeting the browser, the server and native controls.
+/// </summary>
+/// <typeparam name="TModel">The model type.</typeparam>
+/// <typeparam name="TArgument">The initialization argument type.</typeparam>
+public interface ProgramCore<TModel, TArgument> : Decider<TModel, Message, Message, Command, Message, TArgument>
 {
+    /// <summary>Validates a message against the current model.</summary>
     new static abstract Result<Message[], Message> Decide(TModel state, Message command);
 
+    /// <summary>Whether the program has reached a terminal state.</summary>
     new static abstract bool IsTerminal(TModel state);
 
-    static abstract Document View(TModel model);
-
+    /// <summary>The subscriptions the model currently wants active.</summary>
     static abstract Subscription Subscriptions(TModel model);
+}
+
+/// <summary>
+/// How a model is drawn. Separate from <see cref="ProgramCore{TModel, TArgument}"/>
+/// so a per-platform view can be paired with a shared core via
+/// <see cref="WithView{TCore, TView, TModel, TArgument}"/>.
+/// </summary>
+/// <typeparam name="TModel">The model type.</typeparam>
+public interface ProgramView<TModel>
+{
+    /// <summary>Renders the model to a document.</summary>
+    static abstract Document View(TModel model);
+}
+
+/// <summary>
+/// A complete program: a core plus a view. Unchanged from before the Core/View
+/// split — existing programs implement this exactly as they always have, and
+/// the runtime still takes a single <c>TProgram</c>.
+/// </summary>
+/// <typeparam name="TModel">The model type.</typeparam>
+/// <typeparam name="TArgument">The initialization argument type.</typeparam>
+public interface Program<TModel, TArgument> : ProgramCore<TModel, TArgument>, ProgramView<TModel>;
+
+/// <summary>
+/// Pairs a shared <typeparamref name="TCore"/> with a per-platform
+/// <typeparamref name="TView"/> to form a complete <see cref="Program{TModel, TArgument}"/>.
+/// <para>
+/// C# cannot inherit static abstract implementations, so without this a program
+/// that only wants to swap the view still has to hand-forward every core member
+/// to the shared class. This does that forwarding once, in the framework:
+/// </para>
+/// <code>
+/// Runtime&lt;WithView&lt;CounterProgram, NativeCounterView, CounterModel, Unit&gt;, CounterModel, Unit&gt;.Start(...)
+/// </code>
+/// </summary>
+/// <typeparam name="TCore">The shared core.</typeparam>
+/// <typeparam name="TView">The platform-specific view.</typeparam>
+/// <typeparam name="TModel">The model type.</typeparam>
+/// <typeparam name="TArgument">The initialization argument type.</typeparam>
+public sealed class WithView<TCore, TView, TModel, TArgument> : Program<TModel, TArgument>
+    where TCore : ProgramCore<TModel, TArgument>
+    where TView : ProgramView<TModel>
+{
+    /// <inheritdoc cref="Automaton{TState, TEvent, TEffect, TParameters}.Initialize" />
+    public static (TModel, Command) Initialize(TArgument argument) => TCore.Initialize(argument);
+
+    /// <inheritdoc cref="Automaton{TState, TEvent, TEffect, TParameters}.Transition" />
+    public static (TModel, Command) Transition(TModel model, Message message) => TCore.Transition(model, message);
+
+    /// <inheritdoc cref="ProgramCore{TModel, TArgument}.Decide" />
+    public static Result<Message[], Message> Decide(TModel state, Message command) => TCore.Decide(state, command);
+
+    /// <inheritdoc cref="ProgramCore{TModel, TArgument}.IsTerminal" />
+    public static bool IsTerminal(TModel state) => TCore.IsTerminal(state);
+
+    /// <inheritdoc cref="ProgramCore{TModel, TArgument}.Subscriptions" />
+    public static Subscription Subscriptions(TModel model) => TCore.Subscriptions(model);
+
+    /// <inheritdoc cref="ProgramView{TModel}.View" />
+    public static Document View(TModel model) => TView.View(model);
 }
 
 public record Url(IReadOnlyList<string> Path, IReadOnlyDictionary<string, string> Query, Option<string> Fragment)

--- a/docs/adr/ADR-027-native-winui-renderer.md
+++ b/docs/adr/ADR-027-native-winui-renderer.md
@@ -70,8 +70,9 @@ that everything a renderer needs is public. See
   was first committed. Access through the derived type is portable, and a project-level
   `.editorconfig` disables IDE0002 to keep it that way. The `windows-latest` CI job is what makes
   this class of divergence visible.
-- `View` is per-platform: a native program must delegate to a shared program class (boilerplate) until the
-  `Program` contract is split into Core + View interfaces.
+- ~~`View` is per-platform: a native program must delegate to a shared program class (boilerplate)~~ —
+  resolved by [ADR-028](./ADR-028-program-core-view-split.md): a native app now supplies a
+  `ProgramView` and pairs it with the shared core via `WithView`, with no forwarding members.
 - The native vocabulary starts small (10 controls) and string-encodes typed properties; breadth, styling,
   and virtualized lists are roadmap work.
 - Uno.Sdk enters the toolchain (`msbuild-sdks` pin in `global.json`), so every root `dotnet restore`

--- a/docs/adr/ADR-028-program-core-view-split.md
+++ b/docs/adr/ADR-028-program-core-view-split.md
@@ -1,0 +1,117 @@
+# ADR-028: Splitting the Program Contract into Core and View
+
+**Status:** Accepted
+**Date:** 2026-08-07
+**Decision Makers:** Maurice Peters
+
+## Context
+
+[ADR-027](./ADR-027-native-winui-renderer.md) established native WinUI as a third renderer and claimed
+its headline benefit as "one pure program, three renderers". The native Counter sample demonstrated it —
+but only by paying for it:
+
+```csharp
+public sealed class NativeCounterProgram : Program<CounterModel, Unit>
+{
+    public static (CounterModel, Command) Initialize(Unit a) => CounterProgram.Initialize(a);
+    public static (CounterModel, Command) Transition(CounterModel m, Message msg) => CounterProgram.Transition(m, msg);
+    public static Result<Message[], Message> Decide(CounterModel m, Message c) => CounterProgram.Decide(m, c);
+    public static bool IsTerminal(CounterModel m) => CounterProgram.IsTerminal(m);
+    public static Subscription Subscriptions(CounterModel m) => CounterProgram.Subscriptions(m);
+
+    public static Document View(CounterModel model) => /* the only new code */;
+}
+```
+
+Five members hand-forwarded to say "everything except the view is the same". This is not a style
+preference: `Program<TModel, TArgument>` declares its members as `static abstract`, and **C# cannot
+inherit static abstract implementations**. A type implementing the interface must supply every member
+itself, so sharing a core across platforms has no language-level mechanism.
+
+ADR-027 recorded the cost as a negative consequence: *"`View` is per-platform: a native program must
+delegate to a shared program class (boilerplate) until the `Program` contract is split into Core + View
+interfaces."* This ADR does that split.
+
+## Decision
+
+Split the contract along the seam that already exists conceptually, and add a framework-side adapter that
+performs the forwarding once:
+
+1. **`ProgramCore<TModel, TArgument>`** — initialization, transitions, decisions, termination,
+   subscriptions. Mentions no DOM and no controls: the platform-free half.
+2. **`ProgramView<TModel>`** — `View` alone.
+3. **`Program<TModel, TArgument> : ProgramCore<TModel, TArgument>, ProgramView<TModel>`** — a complete
+   program, structurally identical to what it was before.
+4. **`WithView<TCore, TView, TModel, TArgument>`** — a sealed class implementing `Program` by forwarding
+   core members to `TCore` and `View` to `TView`. The delegation still exists, but it is written once in
+   the framework instead of once per app.
+
+The sample becomes a view and nothing else:
+
+```csharp
+public sealed class NativeCounterView : ProgramView<CounterModel>
+{
+    public static Document View(CounterModel model) => /* ... */;
+}
+
+// Bootstrap pairs the shared core with the native view:
+await Runtime.RunWithView<CounterProgram, NativeCounterView, CounterModel, Unit>(rootHost, window, Unit.Value);
+```
+
+`CounterProgram` is now used *directly* by the native host — the same class the WASM and server hosts
+use, not a copy or a wrapper.
+
+## Consequences
+
+### Positive
+
+- The central claim of ADR-027 is now structurally true rather than true-with-boilerplate. Sharing a
+  program across renderers costs one type argument.
+- `ProgramCore` is a useful concept in its own right: it names the platform-free half of a program, which
+  is exactly what is testable with `Picea.Abies.Testing` and replayable in the time-travel debugger.
+- Multiple views over one core are expressible and tested, which is the general case the native renderer
+  is one instance of.
+
+### Neutral
+
+- **Fully backward compatible.** `Program` requires the same members as before, so every existing program
+  — browser, server, WASM, Conduit, Counter — compiles untouched. The runtime's constraint is still
+  `where TProgram : Program<TModel, TArgument>`; `WithView<...>` simply satisfies it. Verified by a full
+  solution build and 496 tests with no source changes outside the native sample.
+- `WithView` is a type-level composition, so the pairing appears at the bootstrap call site rather than in
+  a declaration. `Runtime.RunWithView` exists to keep that call readable.
+
+### Negative
+
+- The generic parameter list on the composed type is long
+  (`WithView<CounterProgram, NativeCounterView, CounterModel, Unit>`). `RunWithView` hides it at the one
+  place it normally appears, but it surfaces in type errors.
+- Two ways to express a program now exist — implement `Program` directly, or compose with `WithView`.
+  Single-platform apps should keep implementing `Program`; `WithView` is for cores shared across
+  renderers.
+
+## Alternatives Considered
+
+### Alternative 1: Leave the delegation to app authors
+
+Rejected. Five forwarding members per platform per program is the kind of cost that quietly discourages
+the thing the framework is advertising. It also invites drift: a forwarded member can be edited to differ
+from the shared core, silently forking behaviour that looks shared.
+
+### Alternative 2: Make `View` a runtime parameter rather than a type member
+
+Pass `Func<TModel, Document>` to `Runtime.Start` and drop `View` from the contract. Rejected: it moves a
+compile-time guarantee to a runtime one, and the delegate closes over whatever it likes, weakening the
+purity the architecture depends on. It would also be a breaking change for every existing program.
+
+### Alternative 3: Instance-based interfaces instead of static abstract
+
+The inheritance problem is a consequence of `static abstract`. Rejected as far out of scope: the static
+contract is what keeps programs allocation-free and is load-bearing across the whole framework and the
+Picea kernel.
+
+## Related Decisions
+
+- [ADR-001: MVU Architecture](./ADR-001-mvu-architecture.md)
+- [ADR-024: Four Render Modes](./ADR-024-four-render-modes.md)
+- [ADR-027: Native WinUI Renderer](./ADR-027-native-winui-renderer.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ ADRs document significant architectural decisions, their context, and consequenc
 | [ADR-025](./ADR-025-issue-160-debugger-boundary-contract-phase1.md) | Issue #160 Debugger Boundary Contract (Phase 1) | Accepted | Defines debugger boundary contract for phase 1 integration |
 | [ADR-026](./ADR-026-debugger-auto-mount-with-csharp-api.md) | Debugger Auto-Mount with C# API | Accepted | Adds automatic debugger mount behavior with the C# API |
 | [ADR-027](./ADR-027-native-winui-renderer.md) | Native WinUI Renderer via Patch-Stream Interpretation | Accepted | Native controls as a third `Apply` implementation; zero core changes |
+| [ADR-028](./ADR-028-program-core-view-split.md) | Program Core/View Split | Accepted | `ProgramCore` + `ProgramView` + `WithView`; share a core across renderers |
 
 > **Note:** There are two files numbered ADR-005: [ADR-005-webassembly-runtime.md](./ADR-005-webassembly-runtime.md) (indexed above) and [ADR-005-security-scanning-sast-dast-sca.md](./ADR-005-security-scanning-sast-dast-sca.md) (security scanning). The security scanning ADR was created separately and retains its number for historical reasons.
 

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -108,6 +108,12 @@ the friction is gone.
 must hand-delegate `Initialize`/`Transition`/`Decide`/`IsTerminal`/`Subscriptions`
 to a shared class. Fine for a spike, unacceptable as the documented pattern.
 
+**Fixed** — see [ADR-028](../adr/ADR-028-program-core-view-split.md). `Program` now
+composes `ProgramCore` + `ProgramView`, and `WithView<TCore, TView, ...>` does the
+forwarding once in the framework. The sample is a view and nothing else; the native
+host uses `CounterProgram` directly. Fully backward compatible — 496 tests and a full
+solution build pass with no source changes outside the native sample.
+
 **D3 — `INativeBackend.InsertBefore` is dead API.** Declared, implemented twice,
 never called — the interpreter always appends on `AddChild` and relies on
 subsequent `MoveChild` patches for ordering. Either wire it up or delete it before
@@ -243,9 +249,8 @@ Everything here is breaking, so it must precede packaging.
 
 - **D1 ✅ done**: enums renamed to `StackOrientation` / `TextWeight`; all three alias
   workarounds deleted from the sample.
-- **D2**: split `Program` into Core + View interfaces; remove native delegation
-  boilerplate. This touches the core, so it needs its own ADR and a compatibility
-  review against browser/server programs.
+- **D2 ✅ done** (ADR-028): `ProgramCore` + `ProgramView` + `WithView`. Backward
+  compatible; browser/server/WASM/Conduit programs unchanged.
 - **N5**: ADR-021 Roslyn analyzer for reserved void-element tag names and the
   element-only-tree rule, promoting both runtime tripwires to compile-time errors.
 - **N4**: pick and document a controlled-input strategy for `TextBox`.


### PR DESCRIPTION
Phase 2 item **D2**, with [ADR-028](https://github.com/Picea/Abies/blob/feat/program-core-view-split/docs/adr/ADR-028-program-core-view-split.md) as the plan required.

### What

`Program` is now composed rather than monolithic:

- **`ProgramCore<TModel, TArgument>`** — initialize, transition, decide, terminate, subscribe. Mentions no DOM: the platform-free half.
- **`ProgramView<TModel>`** — `View` alone.
- **`Program<TModel, TArgument> : ProgramCore<…>, ProgramView<…>`** — the same complete contract as before.
- **`WithView<TCore, TView, TModel, TArgument>`** — forwards core members to `TCore`, `View` to `TView`.

### Why

ADR-027 claimed "one pure program, three renderers", but the native sample paid for it with five hand-forwarded members:

```csharp
public static (CounterModel, Command) Initialize(Unit a) => CounterProgram.Initialize(a);
public static (CounterModel, Command) Transition(CounterModel m, Message msg) => CounterProgram.Transition(m, msg);
public static Result<Message[], Message> Decide(CounterModel m, Message c) => CounterProgram.Decide(m, c);
public static bool IsTerminal(CounterModel m) => CounterProgram.IsTerminal(m);
public static Subscription Subscriptions(CounterModel m) => CounterProgram.Subscriptions(m);
public static Document View(CounterModel model) => /* the only new code */;
```

This isn't a style preference. `Program`'s members are `static abstract`, and **C# cannot inherit static abstract implementations** — so sharing a core across platforms had no language-level mechanism. The delegation still has to happen; the question is whether it's written once in the framework or once per app.

Beyond the boilerplate, forwarding invites drift: a forwarded member can be edited to differ from the shared core, silently forking behaviour that still *looks* shared.

### The result

The sample is now a view and nothing else, and the native host uses `CounterProgram` **directly** — the same class the WASM and server hosts use:

```csharp
public sealed class NativeCounterView : ProgramView<CounterModel>
{
    public static Document View(CounterModel model) => /* ... */;
}

await Runtime.RunWithView<CounterProgram, NativeCounterView, CounterModel, Unit>(rootHost, window, Unit.Value);
```

### Backward compatibility

**Nothing outside the native sample changed.** `Program` requires the same members it always did, so existing programs compile untouched, and the runtime's constraint is still `where TProgram : Program<TModel, TArgument>` — `WithView<…>` simply satisfies it.

Verified across the whole framework:

| Suite | Result |
| --- | --- |
| Full solution build | ✅ 0 errors |
| `Picea.Abies.Tests` | ✅ 224 |
| `Picea.Abies.Server.Tests` | ✅ 18 |
| `Picea.Abies.Server.Kestrel.Tests` | ✅ 54 |
| `Picea.Abies.Conduit.Tests` | ✅ 130 |
| `Picea.Abies.Conduit.Wasm.Tests` | ✅ 41 |
| `Picea.Abies.Testing.Tests` | ✅ 29 |
| `Picea.Abies.Native.Tests` | ✅ 26 |

**496 tests, zero source changes outside `Picea.Abies.Counter.Native`.**

### Testing

Two new tests cover the composition itself: `WithView` driving a full MVU loop from a shared core, and **two different views over the same core** — the general case the native renderer is just one instance of.

### Trade-offs (also in the ADR)

- The composed generic is verbose (`WithView<CounterProgram, NativeCounterView, CounterModel, Unit>`). `RunWithView` hides it at the one place it normally appears, but it surfaces in type errors.
- There are now two ways to express a program. Single-platform apps should keep implementing `Program` directly; `WithView` is for cores shared across renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)