### PR TITLE
feat(analyzers): Enforce native tree rules at compile time; preserve TextBox caret

### DIFF
--- a/Picea.Abies.Analyzers.Tests/AbiesStubs.cs
+++ b/Picea.Abies.Analyzers.Tests/AbiesStubs.cs
@@ -21,6 +21,7 @@ internal static class AbiesStubs
             public record Node(string Id);
             public record Element(string Id, string Tag, Attribute[] Attributes, params Node[] Children) : Node(Id);
             public record Text(string Id, string Value) : Node(Id);
+            public record RawHtml(string Id, string Html) : Node(Id);
             public record Attribute(string Id, string Name, string Value);
             public abstract record Message;
         }
@@ -79,6 +80,9 @@ internal static class AbiesStubs
                 // Text factory: (value, id?) → Node
                 public static Node text(string value, string? id = null)
                     => new Text(id ?? "", value);
+
+                public static Node raw(string html, string? id = null)
+                    => new RawHtml(id ?? "", html);
             }
         }
         
@@ -126,6 +130,27 @@ internal static class AbiesStubs
 
                 public static Handler oninput(System.Func<object?, Message> factory, string? id = null)
                     => new(id ?? "", "data-event-input", id ?? "auto");
+            }
+        }
+
+        // ── Picea.Abies.Native stubs ───────────────────────────────────────
+        namespace Picea.Abies.Native
+        {
+            using Picea.Abies.DOM;
+
+            public static class Elements
+            {
+                public static Element element(string tag, DOM.Attribute[] attributes, Node[] children, string? id = null)
+                    => new(id ?? "", tag, attributes, children);
+
+                public static Node StackPanel(DOM.Attribute[] attributes, Node[] children, string? id = null)
+                    => element("StackPanel", attributes, children, id);
+
+                public static Node Border(DOM.Attribute[] attributes, Node child, string? id = null)
+                    => element("Border", attributes, new[] { child }, id);
+
+                public static Node TextBlock(DOM.Attribute[] attributes, string text, string? id = null)
+                    => element("TextBlock", attributes, new Node[0], id);
             }
         }
         """;

--- a/Picea.Abies.Analyzers.Tests/NativeElementAnalyzerTests.cs
+++ b/Picea.Abies.Analyzers.Tests/NativeElementAnalyzerTests.cs
@@ -1,0 +1,229 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Picea.Abies.Analyzers.Tests;
+
+/// <summary>
+/// Tests for <see cref="NativeElementAnalyzer"/> — ABIES008 (reserved void
+/// element tag name) and ABIES009 (non-Element node in a native tree).
+/// </summary>
+public class NativeElementAnalyzerTests
+{
+    private const string Preamble = """
+        using Picea.Abies.DOM;
+        using Picea.Abies.Native;
+        using static Picea.Abies.Native.Elements;
+
+        namespace TestApp;
+
+        public static class TestView
+        {
+        """;
+
+    private const string Postamble = """
+        }
+        """;
+
+    private static string WrapInView(string code) => Preamble + code + Postamble;
+
+    private static CSharpAnalyzerTest<NativeElementAnalyzer, DefaultVerifier> CreateTest(string testCode)
+    {
+        var test = new CSharpAnalyzerTest<NativeElementAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("AbiesStubs.cs", AbiesStubs.Source));
+        return test;
+    }
+
+    // =========================================================================
+    // ABIES008: reserved void element tag names
+    // =========================================================================
+
+    [Test]
+    public async Task NativeTagNamedInput_ReportsABIES008()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    element({|#0:"Input"|}, [], []);
+        """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES008", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("Input"));
+        await test.RunAsync();
+    }
+
+    /// <summary>The diff matches void element names case-insensitively.</summary>
+    [Test]
+    public async Task NativeTagNamedLink_LowerCase_ReportsABIES008()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    element({|#0:"link"|}, [], []);
+        """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES008", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("link"));
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task NativeTagNamedSource_ReportsABIES008()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    element({|#0:"Source"|}, [], []);
+        """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES008", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("Source"));
+        await test.RunAsync();
+    }
+
+    /// <summary>"Image" is a WinUI control and is not an HTML void element.</summary>
+    [Test]
+    public async Task NativeTagNamedImage_IsClean()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    element("Image", [], []);
+        """));
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task OrdinaryNativeTag_IsClean()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    element("StackPanel", [], []);
+        """));
+        await test.RunAsync();
+    }
+
+    /// <summary>A computed tag cannot be checked statically; no false positive.</summary>
+    [Test]
+    public async Task NonLiteralTag_IsNotReported()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View(string tag) =>
+                    element(tag, [], []);
+        """));
+        await test.RunAsync();
+    }
+
+    // =========================================================================
+    // ABIES009: non-Element nodes in a native tree
+    // =========================================================================
+
+    [Test]
+    public async Task TextNodeInsideNativeElement_ReportsABIES009()
+    {
+        var test = CreateTest("""
+        using Picea.Abies.DOM;
+        using Picea.Abies.Native;
+        using static Picea.Abies.Native.Elements;
+        using static Picea.Abies.Html.Elements;
+
+        namespace TestApp;
+
+        public static class TestView
+        {
+                public static Node View() =>
+                    StackPanel([], [{|#0:text("oops")|}]);
+        }
+        """);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES009", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("text"));
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task RawNodeInsideNativeElement_ReportsABIES009()
+    {
+        var test = CreateTest("""
+        using Picea.Abies.DOM;
+        using Picea.Abies.Native;
+        using static Picea.Abies.Native.Elements;
+        using static Picea.Abies.Html.Elements;
+
+        namespace TestApp;
+
+        public static class TestView
+        {
+                public static Node View() =>
+                    Border([], {|#0:raw("<b>no</b>")|});
+        }
+        """);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES009", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("raw"));
+        await test.RunAsync();
+    }
+
+    /// <summary>
+    /// Nesting must produce exactly one diagnostic, at the offending node —
+    /// not one per enclosing native element.
+    /// </summary>
+    [Test]
+    public async Task TextNestedTwoDeep_ReportsOnceAtTheNode()
+    {
+        var test = CreateTest("""
+        using Picea.Abies.DOM;
+        using Picea.Abies.Native;
+        using static Picea.Abies.Native.Elements;
+        using static Picea.Abies.Html.Elements;
+
+        namespace TestApp;
+
+        public static class TestView
+        {
+                public static Node View() =>
+                    StackPanel([], [StackPanel([], [{|#0:text("oops")|}])]);
+        }
+        """);
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult("ABIES009", DiagnosticSeverity.Error)
+                .WithLocation(0)
+                .WithArguments("text"));
+        await test.RunAsync();
+    }
+
+    /// <summary>text() in an ordinary HTML tree is entirely normal.</summary>
+    [Test]
+    public async Task TextInsideHtmlElement_IsClean()
+    {
+        var test = CreateTest("""
+        using Picea.Abies.DOM;
+        using static Picea.Abies.Html.Elements;
+
+        namespace TestApp;
+
+        public static class TestView
+        {
+                public static Node View() =>
+                    div([], [text("fine")]);
+        }
+        """);
+        await test.RunAsync();
+    }
+
+    /// <summary>A native tree carrying text as a property is the correct shape.</summary>
+    [Test]
+    public async Task NativeTreeWithTextBlock_IsClean()
+    {
+        var test = CreateTest(WrapInView("""
+                public static Node View() =>
+                    StackPanel([], [TextBlock([], "fine")]);
+        """));
+        await test.RunAsync();
+    }
+}

--- a/Picea.Abies.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Picea.Abies.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,5 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ABIES006 | Picea.Abies.Html | Warning | Repeated interactive controls should use explicit stable handler ids
 ABIES007 | Picea.Abies.Html | Warning | Repeated helper invocations that emit interactive controls should use explicit stable handler ids
+ABIES008 | Picea.Abies.Native | Error | NativeElementAnalyzer, native tag collides with an HTML void element name
+ABIES009 | Picea.Abies.Native | Error | NativeElementAnalyzer, Text or RawHtml node inside a native element tree

--- a/Picea.Abies.Analyzers/DiagnosticDescriptors.cs
+++ b/Picea.Abies.Analyzers/DiagnosticDescriptors.cs
@@ -10,6 +10,7 @@ internal static class DiagnosticDescriptors
     private const string _category = "Picea.Abies.Html";
     private const string _accessibilityCategory = "Picea.Abies.Html.Accessibility";
     private const string _contentModelCategory = "Picea.Abies.Html.ContentModel";
+    private const string _nativeCategory = "Picea.Abies.Native";
 
     // =========================================================================
     // ABIES001: img() missing alt attribute
@@ -101,4 +102,30 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Helpers that render interactive controls can hide event handlers from the immediate call site. When those helpers are invoked in repeated paths, handlers inside the helper should use explicit ids to preserve per-instance identity.",
         helpLinkUri: "https://github.com/Picea/Abies/blob/main/docs/api/html-events.md");
+
+    // =========================================================================
+    // ABIES008: Native tag collides with an HTML void element name
+    // =========================================================================
+    public static readonly DiagnosticDescriptor NativeReservedTagName = new(
+        id: "ABIES008",
+        title: "Native element tag collides with an HTML void element name",
+        messageFormat: "Native tag '{0}' collides with an HTML void element name; children of this element will silently never be diffed",
+        category: _nativeCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The diff skips child diffing for tags in HtmlSpec.VoidElements, matched case-insensitively. A native element using one of those names (area, base, br, col, embed, hr, img, input, link, meta, param, source, track, wbr) would render once and then never update its children, with no error. Choose a different tag name.",
+        helpLinkUri: "https://github.com/Picea/Abies/blob/main/docs/adr/ADR-027-native-winui-renderer.md");
+
+    // =========================================================================
+    // ABIES009: Text or RawHtml node inside a native element tree
+    // =========================================================================
+    public static readonly DiagnosticDescriptor NativeNonElementChild = new(
+        id: "ABIES009",
+        title: "Text or raw HTML node inside a native element tree",
+        messageFormat: "'{0}()' produces a non-Element node, which is not supported inside a native element tree",
+        category: _nativeCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Native trees contain only Element nodes; text is carried as a Text or Content attribute. A Text or RawHtml child makes the diff take an HTML fallback path, which the native patch interpreter rejects at runtime. Use TextBlock(...) or a Content-bearing control instead.",
+        helpLinkUri: "https://github.com/Picea/Abies/blob/main/docs/adr/ADR-027-native-winui-renderer.md");
 }

--- a/Picea.Abies.Analyzers/NativeElementAnalyzer.cs
+++ b/Picea.Abies.Analyzers/NativeElementAnalyzer.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Picea.Abies.Analyzers;
+
+/// <summary>
+/// Enforces the two structural rules that keep the HTML fallback paths out of
+/// native element trees (ADR-027). Both were runtime tripwires in the patch
+/// interpreter; this promotes them to compile time, per ADR-021's preference
+/// for analyzers over a more restrictive typed DSL.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item>ABIES008: a native tag that collides with an HTML void element name.</item>
+/// <item>ABIES009: a Text or RawHtml node inside a native element tree.</item>
+/// </list>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NativeElementAnalyzer : DiagnosticAnalyzer
+{
+    private const string NativeElementsType = "Picea.Abies.Native.Elements";
+    private const string HtmlElementsType = "Picea.Abies.Html.Elements";
+
+    /// <summary>
+    /// The HTML void elements, matched case-insensitively exactly as
+    /// <c>HtmlSpec.VoidElements</c> does in the diff.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> VoidElementNames =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "area", "base", "br", "col", "embed",
+            "hr", "img", "input", "link", "meta",
+            "param", "source", "track", "wbr");
+
+    /// <summary>Html factories that produce non-Element nodes.</summary>
+    private static readonly ImmutableHashSet<string> NonElementFactories =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "text", "raw");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            DiagnosticDescriptors.NativeReservedTagName,
+            DiagnosticDescriptors.NativeNonElementChild);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
+        {
+            return;
+        }
+
+        var containingType = method.ContainingType?.ToDisplayString();
+
+        if (containingType == NativeElementsType)
+        {
+            AnalyzeReservedTagName(context, invocation, method);
+        }
+        else if (containingType == HtmlElementsType && NonElementFactories.Contains(method.Name))
+        {
+            AnalyzeNonElementChild(context, invocation, method);
+        }
+    }
+
+    /// <summary>
+    /// ABIES008 — <c>element("Input", ...)</c> and friends. The diff skips child
+    /// diffing for void element tags, so such a subtree silently stops updating.
+    /// </summary>
+    private static void AnalyzeReservedTagName(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method)
+    {
+        // Only the general-purpose factory takes a caller-supplied tag; the
+        // named factories hard-code safe tags.
+        if (method.Name != "element")
+        {
+            return;
+        }
+
+        var tagArgument = invocation.ArgumentList.Arguments.FirstOrDefault();
+        if (tagArgument?.Expression is not LiteralExpressionSyntax literal ||
+            !literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            // Non-literal tags cannot be checked here; the interpreter still
+            // throws for unknown tags at runtime.
+            return;
+        }
+
+        var tag = literal.Token.ValueText;
+        if (VoidElementNames.Contains(tag))
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DiagnosticDescriptors.NativeReservedTagName,
+                    tagArgument.GetLocation(),
+                    tag));
+        }
+    }
+
+    /// <summary>
+    /// ABIES009 — a <c>text(...)</c> or <c>raw(...)</c> node inside a native
+    /// tree. Reported at the offending node rather than at the enclosing
+    /// element, so nesting produces exactly one diagnostic.
+    /// </summary>
+    private static void AnalyzeNonElementChild(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method)
+    {
+        if (!IsInsideNativeElement(invocation, context))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                DiagnosticDescriptors.NativeNonElementChild,
+                invocation.GetLocation(),
+                method.Name));
+    }
+
+    /// <summary>
+    /// Walks outward to the nearest enclosing element factory. Native means a
+    /// violation; HTML means this subtree is an ordinary HTML tree and the node
+    /// is fine.
+    /// </summary>
+    private static bool IsInsideNativeElement(SyntaxNode node, SyntaxNodeAnalysisContext context)
+    {
+        foreach (var ancestor in node.Ancestors().OfType<InvocationExpressionSyntax>())
+        {
+            if (context.SemanticModel.GetSymbolInfo(ancestor, context.CancellationToken).Symbol
+                is not IMethodSymbol ancestorMethod)
+            {
+                continue;
+            }
+
+            var type = ancestorMethod.ContainingType?.ToDisplayString();
+            if (type == NativeElementsType)
+            {
+                return true;
+            }
+
+            if (type == HtmlElementsType)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -162,7 +162,17 @@ public static class Properties
     public static DOM.Attribute IsEnabled(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("IsEnabled", value ? "True" : "False", id);
 
-    /// <summary>TextBox text (two-way: pair with OnTextChanged).</summary>
+    /// <summary>
+    /// TextBox text (two-way: pair with <c>Events.OnTextChanged</c>).
+    /// <para>
+    /// The backend skips writes that would not change the text, so ordinary
+    /// typing never disturbs the caret. When the model transforms the input
+    /// (upper-casing, trimming) the write does happen, and the backend restores
+    /// the selection around it, clamped to the new length. A model that
+    /// rewrites the whole string will still move the caret — there is no
+    /// general answer for where it should land after an arbitrary rewrite.
+    /// </para>
+    /// </summary>
     public static DOM.Attribute Text(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Text", value, id);
 

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -210,11 +210,7 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                 switch (name)
                 {
                     case "Text":
-                        // Only write on real change: rewriting identical text
-                        // still resets the caret on some platforms.
-                        var newText = value ?? "";
-                        if (tx.Text != newText)
-                            tx.Text = newText;
+                        SetTextPreservingCaret(tx, value ?? "");
                         return;
                     case "PlaceholderText":
                         tx.PlaceholderText = value ?? "";
@@ -376,6 +372,50 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
     {
         _rootHost.Children.Clear();
         _rootHost.Children.Add(root);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="newText"/> to a TextBox without destroying the
+    /// user's caret position.
+    /// </summary>
+    /// <remarks>
+    /// Controlled inputs are the awkward case in any MVU renderer: the model is
+    /// the source of truth, but the control also holds cursor state the model
+    /// knows nothing about. Abies-native's strategy is deliberately narrow:
+    /// <list type="number">
+    /// <item>
+    /// Identical writes are skipped entirely. This is the common case — the
+    /// model echoes back exactly what the user typed — and skipping it means
+    /// ordinary typing never touches the caret at all.
+    /// </item>
+    /// <item>
+    /// When the text genuinely differs, the model has transformed the input
+    /// (upper-casing, trimming, formatting). The write must happen, so the
+    /// selection is captured and restored around it, clamped to the new length
+    /// because the transformation may have shortened the text.
+    /// </item>
+    /// </list>
+    /// This keeps the caret stable for edits at or before the cursor. It does
+    /// not attempt to map a caret through an arbitrary transformation — a
+    /// model that rewrites the whole string will still move the cursor, which
+    /// is the honest outcome, since there is no general answer to "where should
+    /// the caret be" after an arbitrary rewrite.
+    /// </remarks>
+    private static void SetTextPreservingCaret(TextBox textBox, string newText)
+    {
+        if (textBox.Text == newText)
+        {
+            return;
+        }
+
+        var selectionStart = textBox.SelectionStart;
+        var selectionLength = textBox.SelectionLength;
+
+        textBox.Text = newText;
+
+        var start = Math.Min(selectionStart, newText.Length);
+        textBox.SelectionStart = start;
+        textBox.SelectionLength = Math.Min(selectionLength, newText.Length - start);
     }
 
     private static NotSupportedException ChildrenNotSupported(string parentTag) =>

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -135,10 +135,26 @@ Same echo/jitter class of problem.
 `_ = dispatch(message)` swallows dispatch failures.
 
 **N4 — Unresolved TextBox controlled-input strategy.** Caret can jump if a patch
-rewrites `Text` mid-typing. Documented, not solved.
+rewrites `Text` mid-typing.
+
+**Resolved.** The strategy is deliberately narrow and now documented on
+`Properties.Text`: identical writes are skipped, so ordinary typing never touches the
+caret; when the model genuinely transforms the input the write happens and the
+selection is captured and restored around it, clamped to the new length. It does not
+try to map a caret through an arbitrary transformation — a model that rewrites the
+whole string still moves the cursor, which is the honest outcome, because there is no
+general answer to where the caret belongs after an arbitrary rewrite.
 
 **N5 — Reserved-tag and element-only-tree rules are runtime tripwires only.** The
 ADR-021 analyzer that would make them compile-time errors is unwritten.
+
+**Resolved.** `NativeElementAnalyzer` adds two error-severity rules: **ABIES008** for a
+native tag colliding with an HTML void element name (the diff would silently skip child
+diffing, so the subtree renders once and never updates), and **ABIES009** for a
+`text()`/`raw()` node inside a native tree. ABIES009 reports at the offending node
+rather than at each enclosing element, so nesting yields exactly one diagnostic, and it
+walks out to the nearest enclosing element factory so `text()` in an ordinary HTML tree
+is untouched.
 
 ### Scope gaps
 
@@ -251,11 +267,13 @@ Everything here is breaking, so it must precede packaging.
   workarounds deleted from the sample.
 - **D2 ✅ done** (ADR-028): `ProgramCore` + `ProgramView` + `WithView`. Backward
   compatible; browser/server/WASM/Conduit programs unchanged.
-- **N5**: ADR-021 Roslyn analyzer for reserved void-element tag names and the
-  element-only-tree rule, promoting both runtime tripwires to compile-time errors.
-- **N4**: pick and document a controlled-input strategy for `TextBox`.
+- **N5 ✅ done**: `NativeElementAnalyzer` (ABIES008, ABIES009), 11 tests.
+- **N4 ✅ done**: caret-preserving controlled-input strategy, documented on
+  `Properties.Text`.
 
 **Exit:** public API reviewed and frozen; no known breaking changes pending.
+**Reached** — D1, D2, N4 and N5 are all done. The two breaking changes (D1, D2) landed
+before packaging, which was the whole point of sequencing the freeze ahead of Phase 4.
 
 ### Phase 3 — Breadth and scale (~2–3 weeks)
 

--- a/docs/research/native-winui-mvu.md
+++ b/docs/research/native-winui-mvu.md
@@ -134,8 +134,8 @@ The spike was landed with three fixes, all covered by new tests:
 **Spike-accepted limitations**
 
 - Vocabulary is 10 controls with a pragmatic property set; unknown tags/properties throw by design.
-- `TextBox` caret can jump if a patch rewrites `Text` mid-typing (identical-text writes are skipped; a
-  controlled-input strategy is future work).
+- ~~`TextBox` caret can jump if a patch rewrites `Text` mid-typing~~ — resolved: identical writes are
+  skipped and the selection is restored around genuine rewrites. See `Properties.Text`.
 - Praefixum ids are per call site: elements created in loops must set `Properties.Id`/`Properties.Key`
   (same rule as the HTML DSL).
 - ~~DSL friction: `Properties` method names shadow the identically-named enums under `using static`~~ —
@@ -147,8 +147,7 @@ The spike was landed with three fixes, all covered by new tests:
 
 1. **Phase 2 — vocabulary & ergonomics**: broaden controls (ItemsView, NavigationView, ContentDialog),
    element-content `Button`/`ContentControl` children, styling/theming story (map to XAML theme resources
-   rather than reinventing), Roslyn analyzer (per ADR-021) for the
-   reserved-void-tag and Element-only-trees rules, split the `Program` contract into Core + View interfaces
+   rather than reinventing), split the `Program` contract into Core + View interfaces
    to remove native-program delegation boilerplate.
 2. **Phase 3 — scale & platform**: virtualized lists via an `ItemsRepeater` escape hatch (Reactor's
    recycling is the benchmark), accessibility/automation-peer pass, `net10.0-windows10.0.26100` head


### PR DESCRIPTION
The last two Phase 2 items (**N5**, **N4**), completing the [production-readiness plan's](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md) API-freeze phase.

### What

- **`NativeElementAnalyzer`** with two error-severity rules, **ABIES008** and **ABIES009** (N5).
- **Caret-preserving `TextBox` writes** in `WinUIBackend`, with the strategy documented on `Properties.Text` (N4).

### Why

**N5.** ADR-027 relied on two structural rules to keep the diff's HTML fallback paths out of native trees, and enforced both only as *runtime* tripwires.

**ABIES008 — native tag collides with an HTML void element name.** The diff matches `HtmlSpec.VoidElements` case-insensitively and skips child diffing for those tags:

```csharp
if (!HtmlSpec.VoidElements.Contains(oldElement.Tag))
    DiffChildren(oldElement, newElement, patches);
```

So `element("Input", ...)` renders once and then **never updates its children, with no error**. That is precisely the failure a runtime tripwire cannot catch — nothing throws, the UI just goes stale. Compile time is the only place to catch it.

**ABIES009 — `text()`/`raw()` inside a native tree.** Native trees carry text as an attribute, never as a child node. Reported at the offending node rather than at each enclosing element, so nesting yields exactly one diagnostic; resolution walks out to the *nearest* enclosing element factory, so `text()` in an ordinary HTML tree is untouched.

Non-literal tags are deliberately **not** reported — they cannot be checked statically, and the interpreter still rejects unknown tags at runtime. Better no diagnostic than a false one.

**N4.** Controlled inputs are the awkward case in any MVU renderer: the model owns the text, but the control owns cursor state the model knows nothing about. The strategy is narrow on purpose:

1. **Identical writes are skipped.** This is the common case — the model echoes back what the user typed — so ordinary typing never touches the caret at all.
2. **When the text genuinely differs**, the model has transformed it (upper-casing, trimming). The write must happen, so the selection is captured and restored around it, clamped to the new length.

It does **not** try to map a caret through an arbitrary transformation. A model that rewrites the whole string still moves the cursor — the honest outcome, since there is no general answer for where the caret belongs after an arbitrary rewrite. That limitation is documented on `Properties.Text` rather than left to be discovered.

### Testing

| Suite | Result |
| --- | --- |
| `Picea.Abies.Analyzers.Tests` | ✅ 40 (11 new) |
| `Picea.Abies.Tests` | ✅ 224 |
| `Picea.Abies.Native.Tests` | ✅ 26 |
| Full solution build | ✅ 0 errors |

New analyzer tests cover the cases most likely to be got wrong: case-insensitive matching (`"link"`), `"Image"` being a legitimate WinUI control rather than a void element, non-literal tags producing no diagnostic, nesting reporting once, and `text()` in an HTML tree staying clean.

`dotnet format --verify-no-changes` clean across all four touched projects; `AnalyzerReleases.Unshipped.md` updated as the release-tracking analyzer requires.

### Phase 2 is now complete

D1, D2, N4, N5 all done — and both breaking changes (D1, D2) landed **before** packaging, which was the entire point of sequencing the freeze ahead of Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)