### PR TITLE
feat(native): Broaden the control vocabulary and support element content

### DIFF
--- a/Picea.Abies.Native.Tests/VocabularyTests.cs
+++ b/Picea.Abies.Native.Tests/VocabularyTests.cs
@@ -1,0 +1,152 @@
+// =============================================================================
+// Vocabulary Tests
+// =============================================================================
+// Covers the controls added beyond the original ten, driving the real
+// Operations.Diff so the element shapes are exercised the way a view produces
+// them rather than through hand-built patches.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Picea.Abies.Native.Rendering;
+using static Picea.Abies.Native.Elements;
+using static Picea.Abies.Native.Events;
+using static Picea.Abies.Native.Properties;
+
+namespace Picea.Abies.Native.Tests;
+
+public record Chose(int Index) : Message;
+public record Switched(bool On) : Message;
+
+public class VocabularyTests
+{
+    private static (PatchInterpreter<FakeControl> Interpreter, FakeBackend Backend) Create()
+    {
+        var backend = new FakeBackend();
+        return (new PatchInterpreter<FakeControl>(backend), backend);
+    }
+
+    private static Node Root(params Node[] children) => StackPanel([], children);
+
+    [Test]
+    public async Task ComboBox_BuildsItemsAsChildren()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)Root(
+            ComboBox([SelectedIndex(1)],
+            [
+                ComboBoxItem([Id("i-a")], "Alpha"),
+                ComboBoxItem([Id("i-b")], "Beta"),
+            ]));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        var combo = backend.Root!.Children[0];
+        await Assert.That(combo.Tag).IsEqualTo("ComboBox");
+        await Assert.That(combo.Props["SelectedIndex"]).IsEqualTo("1");
+        await Assert.That(combo.Children.Select(c => c.Props["Content"]!)).IsEquivalentTo(new[] { "Alpha", "Beta" });
+    }
+
+    [Test]
+    public async Task ComboBoxItems_ReorderByKeyWithoutRecreating()
+    {
+        var (interpreter, backend) = Create();
+
+        static Node Options(params string[] names) =>
+            ComboBox([Id("combo")],
+                [.. names.Select(n => ComboBoxItem([Id($"i-{n}"), Key(n)], n))]);
+
+        var old = (Element)Root(Options("a", "b", "c"));
+        var @new = (Element)Root(Options("c", "a", "b"));
+
+        interpreter.Apply(Operations.Diff(null, old));
+        var createdAfterFirstRender = backend.AllCreated.Count;
+        interpreter.Apply(Operations.Diff(old, @new));
+
+        var order = backend.Root!.Children[0].Children.Select(c => c.Id).ToArray();
+        await Assert.That(order).IsEquivalentTo(new[] { "i-c", "i-a", "i-b" });
+        await Assert.That(backend.AllCreated.Count).IsEqualTo(createdAfterFirstRender);
+    }
+
+    [Test]
+    public async Task ToggleSwitch_CarriesStateAndDispatches()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)Root(
+            ToggleSwitch([Id("sw"), IsOn(true), OnToggled(d => new Switched(d!.IsChecked))]));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        var sw = backend.Root!.Children[0];
+        await Assert.That(sw.Props["IsOn"]).IsEqualTo("True");
+
+        Message? dispatched = null;
+        interpreter.Dispatch = m => { dispatched = m; return ValueTask.CompletedTask; };
+        interpreter.OnNativeEvent("sw", "Toggled", new ToggledData(false));
+
+        await Assert.That(((Switched)dispatched!).On).IsFalse();
+    }
+
+    [Test]
+    public async Task ComboBox_SelectionChangedDispatchesIndex()
+    {
+        var (interpreter, _) = Create();
+        var view = (Element)Root(
+            ComboBox([Id("combo"), OnSelectionChanged(d => new Chose(d!.SelectedIndex))], []));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        Message? dispatched = null;
+        interpreter.Dispatch = m => { dispatched = m; return ValueTask.CompletedTask; };
+        interpreter.OnNativeEvent("combo", "SelectionChanged", new SelectionChangedData(2));
+
+        await Assert.That(((Chose)dispatched!).Index).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Progress_CarriesItsProperties()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)Root(
+            ProgressRing([Id("ring"), IsActive(true)]),
+            ProgressBar([Id("bar"), Minimum(0), Maximum(10), Value(4)]));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        await Assert.That(backend.Root!.Children[0].Props["IsActive"]).IsEqualTo("True");
+        await Assert.That(backend.Root!.Children[1].Props["Value"]).IsEqualTo("4");
+    }
+
+    /// <summary>Element content, rather than the string-content overload.</summary>
+    [Test]
+    public async Task Button_AcceptsAnElementTreeAsContent()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)Root(
+            Button([Id("btn")],
+                StackPanel([Id("btn-inner"), Orientation(StackOrientation.Horizontal)],
+                [
+                    TextBlock([Id("btn-icon")], "★"),
+                    TextBlock([Id("btn-label")], "Star"),
+                ])));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        var button = backend.Root!.Children[0];
+        await Assert.That(button.Tag).IsEqualTo("Button");
+        await Assert.That(button.Children[0].Tag).IsEqualTo("StackPanel");
+        await Assert.That(button.Children[0].Children.Select(c => c.Props["Text"]!))
+            .IsEquivalentTo(new[] { "★", "Star" });
+    }
+
+    [Test]
+    public async Task ContentControl_WrapsASubtree()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)Root(
+            ContentControl([Id("host")], TextBlock([Id("inner")], "wrapped")));
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        await Assert.That(backend.Root!.Children[0].Children[0].Props["Text"]).IsEqualTo("wrapped");
+    }
+}

--- a/Picea.Abies.Native/Elements.cs
+++ b/Picea.Abies.Native/Elements.cs
@@ -88,4 +88,45 @@ public static class Elements
     /// <summary>Range slider. Set via Properties.Minimum/Maximum/Value, listen via Events.OnValueChanged.</summary>
     public static Node Slider(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => element("Slider", attributes, [], id);
+
+    /// <summary>Two-state switch. Set via Properties.IsOn, listen via Events.OnToggled.</summary>
+    public static Node ToggleSwitch(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ToggleSwitch", attributes, [], id);
+
+    /// <summary>
+    /// Drop-down list. Children must be <see cref="ComboBoxItem"/>; select via
+    /// Properties.SelectedIndex and listen via Events.OnSelectionChanged.
+    /// </summary>
+    public static Node ComboBox(DOM.Attribute[] attributes, Node[] items, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ComboBox", attributes, items, id);
+
+    /// <summary>An entry in a <see cref="ComboBox"/>; content is carried as a "Content" attribute.</summary>
+    public static Node ComboBoxItem(DOM.Attribute[] attributes, string content, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ComboBoxItem", [.. attributes, new DOM.Attribute(id ?? string.Empty, "Content", content)], [], id);
+
+    // =========================================================================
+    // Progress
+    // =========================================================================
+
+    /// <summary>Indeterminate-by-default spinner; control with Properties.IsActive.</summary>
+    public static Node ProgressRing(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ProgressRing", attributes, [], id);
+
+    /// <summary>Determinate bar via Properties.Minimum/Maximum/Value, or Properties.IsIndeterminate.</summary>
+    public static Node ProgressBar(DOM.Attribute[] attributes, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ProgressBar", attributes, [], id);
+
+    // =========================================================================
+    // Element content
+    // =========================================================================
+    // The string-content overloads above cover the common case. These take a
+    // Node instead, for controls whose content is itself a tree.
+
+    /// <summary>Button whose content is an element tree rather than a string.</summary>
+    public static Node Button(DOM.Attribute[] attributes, Node content, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("Button", attributes, [content], id);
+
+    /// <summary>Bare content host, for wrapping a subtree without adding layout.</summary>
+    public static Node ContentControl(DOM.Attribute[] attributes, Node content, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => element("ContentControl", attributes, [content], id);
 }

--- a/Picea.Abies.Native/EventData.cs
+++ b/Picea.Abies.Native/EventData.cs
@@ -22,3 +22,7 @@ public sealed record ToggledData(bool IsChecked);
 /// <param name="NewValue">The new value.</param>
 /// <param name="OldValue">The previous value.</param>
 public sealed record ValueChangedData(double NewValue, double OldValue);
+
+/// <summary>Payload for selection changes (ComboBox.SelectionChanged).</summary>
+/// <param name="SelectedIndex">The newly selected index, or -1 when nothing is selected.</param>
+public sealed record SelectionChangedData(int SelectedIndex);

--- a/Picea.Abies.Native/Events.cs
+++ b/Picea.Abies.Native/Events.cs
@@ -68,4 +68,8 @@ public static class Events
     /// <summary>Slider value change.</summary>
     public static Handler OnValueChanged(Func<ValueChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => On("ValueChanged", factory, id);
+
+    /// <summary>ComboBox selection change.</summary>
+    public static Handler OnSelectionChanged(Func<SelectionChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("SelectionChanged", factory, id);
 }

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -199,4 +199,20 @@ public static class Properties
     /// <summary>Image source URI.</summary>
     public static DOM.Attribute Source(string uri, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Source", uri, id);
+
+    /// <summary>ToggleSwitch state (pair with OnToggled).</summary>
+    public static DOM.Attribute IsOn(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("IsOn", value ? "True" : "False", id);
+
+    /// <summary>ComboBox selected index; -1 for no selection (pair with OnSelectionChanged).</summary>
+    public static DOM.Attribute SelectedIndex(int value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("SelectedIndex", value.ToString(CultureInfo.InvariantCulture), id);
+
+    /// <summary>Whether a ProgressRing is spinning.</summary>
+    public static DOM.Attribute IsActive(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("IsActive", value ? "True" : "False", id);
+
+    /// <summary>Whether a ProgressBar shows indeterminate progress.</summary>
+    public static DOM.Attribute IsIndeterminate(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("IsIndeterminate", value ? "True" : "False", id);
 }

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -46,6 +46,12 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
         "CheckBox" => new CheckBox(),
         "Slider" => new Slider(),
         "Image" => new Image(),
+        "ToggleSwitch" => new ToggleSwitch(),
+        "ComboBox" => new ComboBox(),
+        "ComboBoxItem" => new ComboBoxItem(),
+        "ProgressRing" => new ProgressRing(),
+        "ProgressBar" => new ProgressBar(),
+        "ContentControl" => new ContentControl(),
         _ => throw new NotSupportedException($"Unknown native tag '{tag}' (element '{elementId}')."),
     };
 
@@ -249,6 +255,61 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                         return;
                 }
                 break;
+            case ToggleSwitch ts:
+                switch (name)
+                {
+                    case "IsOn":
+                        ts.IsOn = value is not null && bool.Parse(value);
+                        return;
+                }
+                break;
+            case ComboBox combo:
+                switch (name)
+                {
+                    case "SelectedIndex":
+                        // Guard identical writes: re-selecting raises SelectionChanged.
+                        var index = value is null ? -1 : I(value);
+                        if (combo.SelectedIndex != index)
+                            combo.SelectedIndex = index;
+                        return;
+                    case "PlaceholderText":
+                        combo.PlaceholderText = value ?? "";
+                        return;
+                }
+                break;
+            case ComboBoxItem cbi:
+                switch (name)
+                {
+                    case "Content":
+                        cbi.Content = value;
+                        return;
+                }
+                break;
+            case ProgressRing pr:
+                switch (name)
+                {
+                    case "IsActive":
+                        pr.IsActive = value is null || bool.Parse(value);
+                        return;
+                }
+                break;
+            case ProgressBar pb:
+                switch (name)
+                {
+                    case "Minimum":
+                        pb.Minimum = value is null ? 0 : D(value);
+                        return;
+                    case "Maximum":
+                        pb.Maximum = value is null ? 100 : D(value);
+                        return;
+                    case "Value":
+                        pb.Value = value is null ? 0 : D(value);
+                        return;
+                    case "IsIndeterminate":
+                        pb.IsIndeterminate = value is not null && bool.Parse(value);
+                        return;
+                }
+                break;
             case Button btn:
                 switch (name)
                 {
@@ -301,6 +362,11 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
             case Border b:
                 b.Child = child;
                 return;
+            // ItemsControl before ContentControl: ComboBox derives from both,
+            // and its children are items, not content.
+            case ItemsControl ic:
+                ic.Items.Add(child);
+                return;
             case ContentControl cc:
                 cc.Content = child;
                 return;
@@ -317,6 +383,9 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                 return;
             case Border b:
                 b.Child = newChild;
+                return;
+            case ItemsControl ic:
+                ic.Items[ic.Items.IndexOf(oldChild)] = newChild;
                 return;
             case ContentControl cc:
                 cc.Content = newChild;
@@ -335,6 +404,9 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
             case Border b when ReferenceEquals(b.Child, child):
                 b.Child = null;
                 return;
+            case ItemsControl ic:
+                ic.Items.Remove(child);
+                return;
             case ContentControl cc when ReferenceEquals(cc.Content, child):
                 cc.Content = null;
                 return;
@@ -343,13 +415,25 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
 
     public void MoveChild(FrameworkElement parent, string parentTag, FrameworkElement child, FrameworkElement? before)
     {
-        if (parent is not Panel p)
-            return; // single-child hosts have nothing to reorder
-        p.Children.Remove(child);
-        if (before is null)
-            p.Children.Add(child);
-        else
-            p.Children.Insert(p.Children.IndexOf(before), child);
+        switch (parent)
+        {
+            case Panel p:
+                p.Children.Remove(child);
+                if (before is null)
+                    p.Children.Add(child);
+                else
+                    p.Children.Insert(p.Children.IndexOf(before), child);
+                return;
+            case ItemsControl ic:
+                ic.Items.Remove(child);
+                if (before is null)
+                    ic.Items.Add(child);
+                else
+                    ic.Items.Insert(ic.Items.IndexOf(before), child);
+                return;
+            default:
+                return; // single-child hosts have nothing to reorder
+        }
     }
 
     public void ClearChildren(FrameworkElement parent, string parentTag)
@@ -361,6 +445,9 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                 return;
             case Border b:
                 b.Child = null;
+                return;
+            case ItemsControl ic:
+                ic.Items.Clear();
                 return;
             case ContentControl cc:
                 cc.Content = null;
@@ -461,6 +548,28 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                     checkBox.Checked -= handler;
                     checkBox.Unchecked -= handler;
                 };
+                return;
+            }
+            case (ToggleSwitch toggle, "Toggled"):
+            {
+                RoutedEventHandler handler = (s, _) =>
+                {
+                    if (!sink.IsApplying)
+                        sink.OnNativeEvent(elementId, "Toggled", new ToggledData(((ToggleSwitch)s).IsOn));
+                };
+                toggle.Toggled += handler;
+                _detachers[(control, eventName)] = () => toggle.Toggled -= handler;
+                return;
+            }
+            case (ComboBox combo, "SelectionChanged"):
+            {
+                SelectionChangedEventHandler handler = (s, _) =>
+                {
+                    if (!sink.IsApplying)
+                        sink.OnNativeEvent(elementId, "SelectionChanged", new SelectionChangedData(((ComboBox)s).SelectedIndex));
+                };
+                combo.SelectionChanged += handler;
+                _detachers[(control, eventName)] = () => combo.SelectionChanged -= handler;
                 return;
             }
             case (Slider slider, "ValueChanged"):


### PR DESCRIPTION
Phase 3 vocabulary work from the [production-readiness plan](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md).

### What

New controls: **ToggleSwitch**, **ComboBox** / **ComboBoxItem**, **ProgressRing**, **ProgressBar**, **ContentControl** — plus a `Button` overload taking a `Node`, so content can be a tree rather than only a string.

Supporting additions: `IsOn`, `SelectedIndex`, `IsActive`, `IsIndeterminate` properties; `OnSelectionChanged` event and `SelectionChangedData`.

### Why

The vocabulary shipped at ten controls, which the ADR recorded as a known limitation. These are the controls an ordinary app reaches for first, and element-content buttons are the common case the string overload cannot express (an icon next to a label).

**ComboBox is the one with a real trap in it.** It derives from *both* `ItemsControl` and `ContentControl`, and its children are items rather than content. The backend's child operations therefore now match `ItemsControl` **before** `ContentControl`:

```csharp
case Border b: ...
// ItemsControl before ContentControl: ComboBox derives from both,
// and its children are items, not content.
case ItemsControl ic: ic.Items.Add(child); return;
case ContentControl cc: cc.Content = child; return;
```

Getting that order wrong puts every item into the content slot, silently displaying only the last one — no exception, just a wrong dropdown. `MoveChild` gained the same branch so keyed reordering works for items exactly as it does for panels.

`SelectedIndex` guards identical writes for the same reason `Slider.Value` and `TextBox.Text` do: re-selecting re-raises `SelectionChanged`.

### Testing

**33 native tests pass** (7 new), all driving the real `Operations.Diff` over the new shapes rather than hand-built patches:

- ComboBox builds items as children with the right content
- **Keyed item reordering moves controls without recreating any** — the assertion that would fail if `ItemsControl` were matched after `ContentControl`
- ToggleSwitch carries state and dispatches through `OnToggled`
- ComboBox `SelectionChanged` dispatches the index
- ProgressRing/ProgressBar carry their properties
- Button with an element tree as content
- ContentControl wrapping a subtree

`dotnet format --verify-no-changes` clean on all three projects; sample still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)