### PR TITLE
build(release): Pack the native packages, with WinUI built on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,67 @@ permissions:
   contents: read
 
 jobs:
+  # Picea.Abies.WinUI resolves net10.0-windows10.0.26100 only on Windows (the
+  # TFM is guarded by IsOSPlatform). Packing it on Linux would silently ship a
+  # package with the Uno Skia head alone and no Windows App SDK target, so it is
+  # packed here and handed to the release job as an artifact.
+  pack-winui:
+    name: Pack Picea.Abies.WinUI (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET (from global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install GitVersioning
+        run: dotnet tool install --global nbgv
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION=$(nbgv get-version -v NuGetPackageVersion)
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Packing Picea.Abies.WinUI as $VERSION"
+
+      - name: Pack Picea.Abies.WinUI (Skia + Windows App SDK heads)
+        run: dotnet pack ./Picea.Abies.WinUI/Picea.Abies.WinUI.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Verify both target frameworks are in the package
+        shell: bash
+        run: |
+          PKG=$(ls ./nupkg/Picea.Abies.WinUI.*.nupkg | head -1)
+          echo "Inspecting $PKG"
+          unzip -l "$PKG" | tee /tmp/pkg-listing.txt
+
+          # A package missing the Windows head would still install and then fail
+          # to resolve for Windows consumers, so fail loudly here instead.
+          grep -q "lib/net10.0-windows10.0.26100" /tmp/pkg-listing.txt \
+            || { echo "❌ Package is missing the Windows App SDK head"; exit 1; }
+          echo "✅ Windows App SDK head present"
+
+      - name: Upload WinUI package
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg-winui
+          path: ./nupkg/*.nupkg
+          if-no-files-found: error
+
   release:
     name: Build, Pack and Publish
     runs-on: ubuntu-latest
+    needs: [pack-winui]
 
     steps:
       - name: Checkout
@@ -89,6 +147,9 @@ jobs:
       - name: Pack Picea.Abies.Server.Kestrel
         run: dotnet pack ./Picea.Abies.Server.Kestrel/Picea.Abies.Server.Kestrel.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
 
+      - name: Pack Picea.Abies.Native
+        run: dotnet pack ./Picea.Abies.Native/Picea.Abies.Native.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
+
       - name: Pack Picea.Abies.Templates
         run: dotnet pack ./Picea.Abies.Templates/Picea.Abies.Templates.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
 
@@ -100,6 +161,15 @@ jobs:
 
       - name: Pack Abies.Server (redirect metapackage)
         run: dotnet pack ./Metapackages/Abies.Server/Abies.Server.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Download the Windows-built WinUI package
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg-winui
+          path: ./nupkg
+
+      - name: List packages to publish
+        run: ls -l ./nupkg
 
       - name: Publish to NuGet
         if: startsWith(github.ref, 'refs/tags/v')

--- a/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
+++ b/Picea.Abies.WinUI/Picea.Abies.WinUI.csproj
@@ -14,6 +14,19 @@
     </UnoFeatures>
   </PropertyGroup>
 
+  <!-- NuGet package metadata -->
+  <PropertyGroup>
+    <PackageId>Picea.Abies.WinUI</PackageId>
+    <Title>Picea.Abies.WinUI</Title>
+    <Description>Native WinUI 3 renderer for the Abies MVU framework. Applies the Abies patch stream to real WinUI controls and provides a one-line bootstrap that marshals rendering to the window's DispatcherQueue. Built with the Uno.Sdk, so the same code targets Windows App SDK on Windows and Uno Platform's Skia heads elsewhere.</Description>
+    <Authors>Maurice Peters</Authors>
+    <PackageTags>picea;abies;winui;uno;native;desktop;mvu;elm;functional</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/picea/abies</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/picea/abies</PackageProjectUrl>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Picea.Abies.Native\Picea.Abies.Native.csproj" />
   </ItemGroup>

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -286,11 +286,25 @@ before packaging, which was the whole point of sequencing the freeze ahead of Ph
   marshaling) plus keyed list reordering in a real app, not just the fake backend.
 - Benchmarks against `microsoft-ui-reactor` for scroll-heavy scenarios.
 
-### Phase 4 — Ship (~1 week)
+### Phase 4 — Ship
 
-- NuGet packages for `Picea.Abies.Native` and `Picea.Abies.WinUI`; add both to
-  `release.yml`'s pack list (currently absent).
-- An `Abies.Native` metapackage alongside `Abies.Browser` / `Abies.Server`.
+**Packaging: done.** `Picea.Abies.WinUI` gained package metadata and both projects
+are packed in `release.yml`.
+
+`Picea.Abies.WinUI` is packed on **`windows-latest`**, not with the rest. Its
+`net10.0-windows10.0.26100` TFM is guarded by `IsOSPlatform('Windows')`, so packing on
+the Linux release runner would silently produce a package containing only the Uno Skia
+head — it would install fine and then fail to resolve for every Windows consumer. The
+Windows job packs it, asserts `lib/net10.0-windows10.0.26100` is actually present in
+the `.nupkg`, and hands it to the release job as an artifact.
+
+**No `Abies.Native` metapackage.** The existing `Abies` / `Abies.Browser` /
+`Abies.Server` metapackages are deprecation shims from the ADR-023 rename, redirecting
+consumers of the old names. There is no historic `Abies.Native` to redirect, so a
+metapackage would create a deprecated package that never had users. Dropped from the
+plan deliberately rather than followed by analogy.
+
+Remaining:
 - `abies-native` template + a smoke-test matrix entry in `pr-validation.yml`
   (note: this adds a Uno restore to the template job — budget for it).
 - Docs: getting-started guide, vocabulary reference, "sharing a program across web


### PR DESCRIPTION
Phase 4 packaging from the [production-readiness plan](https://github.com/Picea/Abies/blob/main/docs/investigations/winui-native-production-readiness.md).

### What

- Package metadata for `Picea.Abies.WinUI`.
- `Picea.Abies.Native` packed alongside the existing packages on Linux.
- `Picea.Abies.WinUI` packed in a **new `windows-latest` job**, verified, and handed to the release job as an artifact.

### Why

**The WinUI package cannot be built on Linux.** Its `net10.0-windows10.0.26100` TFM is guarded by `IsOSPlatform('Windows')` — the guard that keeps Linux CI working. Packing it on the `ubuntu-latest` release runner would produce a package containing only the Uno Skia head: it would upload successfully, install successfully, and then fail to resolve for **every Windows consumer**. A packaging bug that only manifests on a user's machine is exactly the kind worth spending a CI job to prevent.

So the Windows job packs it and then checks its own work:

```bash
grep -q "lib/net10.0-windows10.0.26100" /tmp/pkg-listing.txt \
  || { echo "❌ Package is missing the Windows App SDK head"; exit 1; }
```

If the guard, the TFM, or the SDK ever changes such that the Windows head silently disappears, the release fails loudly instead of shipping a broken package.

### A plan item I deliberately dropped

The plan called for an **`Abies.Native` metapackage** "alongside `Abies.Browser` / `Abies.Server`". Reading those, they are all **deprecation shims from the ADR-023 rename** — they exist solely to redirect consumers of the pre-`Picea.` names:

```xml
<PackageDeprecationMessage>This package has been renamed to Picea.Abies.Browser.</PackageDeprecationMessage>
```

There is no historic `Abies.Native` to redirect from — the package is brand new. Creating one would publish a deprecated package that never had a single user. The plan item was written by analogy without that context, so I dropped it rather than following it mechanically.

### Testing

- `dotnet pack Picea.Abies.Native` verified locally: produces `lib/net10.0/Picea.Abies.Native.dll` plus XML docs, with correct `Picea.Abies` and `Praefixum` dependencies.
- `release.yml` parses as valid YAML; job graph confirmed (`release` now `needs: [pack-winui]`).
- The Windows pack job itself only runs on tag pushes / `workflow_dispatch`, so it is not exercised by this PR's CI — the self-check step above is what guards it in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)