### PR TITLE
docs: Record final phase status for the native renderer

### DIFF
--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -275,16 +275,36 @@ Everything here is breaking, so it must precede packaging.
 **Reached** — D1, D2, N4 and N5 are all done. The two breaking changes (D1, D2) landed
 before packaging, which was the whole point of sequencing the freeze ahead of Phase 4.
 
-### Phase 3 — Breadth and scale (~2–3 weeks)
+### Phase 3 — Breadth and scale
 
-- Vocabulary: `ItemsView`/`ItemsRepeater`, `NavigationView`, `ContentDialog`,
-  `ComboBox`, `ProgressRing`; element-content `Button`/`ContentControl` children.
-- Virtualized list recycling (Reactor's element pooling is the benchmark to beat).
-- Styling/theming: map onto XAML theme resources rather than reinventing.
-- Accessibility/automation-peer pass.
-- The deferred TaskTimer sample: interval subscription (threadpool → dispatcher
-  marshaling) plus keyed list reordering in a real app, not just the fake backend.
-- Benchmarks against `microsoft-ui-reactor` for scroll-heavy scenarios.
+**Vocabulary ✅ done.** Added `ToggleSwitch`, `ComboBox`/`ComboBoxItem`, `ProgressRing`,
+`ProgressBar`, `ContentControl`, and element-content `Button`. ComboBox is the one with a
+trap in it: it derives from both `ItemsControl` and `ContentControl`, so the backend's
+child operations must match `ItemsControl` first or every item lands in the content slot
+and only the last one shows — no exception, just a wrong dropdown. `MoveChild` gained the
+same branch, so keyed reordering works for items as it does for panels.
+
+**Still open, deliberately.** Each of the remaining items is genuinely multi-week, and two
+of them should not be rushed:
+
+- **Virtualized list recycling.** Large lists currently build one control per item.
+  Reactor's element pooling is the benchmark to beat, and matching it is a project, not a
+  patch.
+- **Styling/theming.** This would *add public API*, immediately after Phase 2 froze it.
+  Designing a theming surface under time pressure is the fastest way to acquire the kind
+  of API debt Phase 2 just paid off. It deserves its own ADR: mapping onto XAML theme
+  resources versus a framework-level abstraction is a real decision, not an
+  implementation detail.
+- **Accessibility / automation-peer pass.** Needs a real audit against screen readers,
+  not a plausible-looking API.
+- **TaskTimer sample.** The remaining *verification* gap: the render smoke check proves
+  first render on both heads, but nothing simulates a click, so the
+  event → dispatch → re-render loop is still only verified headlessly against
+  `FakeBackend`. A sample exercising an interval subscription (threadpool → dispatcher
+  marshaling) and keyed list reordering in a real window would close it. **This is the
+  highest-value item remaining.**
+- **Benchmarks against `microsoft-ui-reactor`.** Meaningful only once virtualization
+  exists; benchmarking a non-virtualized list against a virtualized one measures nothing.
 
 ### Phase 4 — Ship
 
@@ -322,6 +342,20 @@ plan deliberately rather than followed by analogy.
   docs index.
 
 ---
+
+## 3a. Status summary
+
+| Phase | Status |
+| --- | --- |
+| 0 — Land the spike | ✅ #321–#324 |
+| 1 — Make the name true | ✅ #326, #327 (compiles, runs and renders on both heads) |
+| 2 — API freeze | ✅ #329–#331 (D1, D2, N4, N5; both breaking changes before packaging) |
+| 3 — Breadth and scale | ◐ vocabulary done (#332); virtualization, theming, accessibility, TaskTimer, benchmarks open |
+| 4 — Ship | ✅ #333–#335 (packages, docs, `dotnet new abies-native`) |
+
+The renderer is usable end-to-end today: `dotnet new abies-native`, `dotnet build`, and a
+window with real WinUI controls driven by a program shared with the web host. What remains
+is depth — scale, polish and a real accessibility story — not viability.
 
 ## 4. Recommendation
 


### PR DESCRIPTION
### What

Updates the production-readiness plan with a status table and an honest account of what remains in Phase 3.

### Why

The plan is the working record of what is actually true about this renderer. Four of five phases are complete and it should say so — but more importantly, it should say precisely what *isn't* done and why, rather than leaving a reader to infer that "mostly done" means "done".

| Phase | Status |
| --- | --- |
| 0 — Land the spike | ✅ #321–#324 |
| 1 — Make the name true | ✅ #326, #327 |
| 2 — API freeze | ✅ #329–#331 |
| 3 — Breadth and scale | ◐ vocabulary done (#332); rest open |
| 4 — Ship | ✅ #333–#335 |

Two Phase 3 items are deliberately **not** rushed, and the doc now says why:

- **Theming would add public API immediately after Phase 2 froze it.** Whether to map onto XAML theme resources or build a framework-level abstraction is a real architectural decision deserving its own ADR — designing it under time pressure is the fastest way to reacquire the API debt Phase 2 just paid off.
- **Benchmarking against `microsoft-ui-reactor` is meaningless until virtualization exists.** Comparing a non-virtualized list to a virtualized one measures nothing.

The remaining **verification** gap is also named plainly: the render smoke check proves first render on both heads, but nothing simulates a click, so the event → dispatch → re-render loop is still only verified headlessly against `FakeBackend`. The TaskTimer sample would close that, and it's flagged as the highest-value item remaining.

### Testing

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)