### PR TITLE
fix(ci): Pin js-framework-benchmark instead of tracking upstream HEAD

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -262,11 +262,33 @@ jobs:
 
       - name: Clone js-framework-benchmark
         if: steps.should-run.outputs.run == 'true'
+        env:
+          # Pinned deliberately. Two reasons:
+          #
+          #  1. Benchmark numbers are only comparable across runs if the harness
+          #     is identical. Tracking upstream HEAD silently changes the thing
+          #     doing the measuring.
+          #  2. Upstream HEAD is currently unbuildable: 89c1c5c1 bumped the root
+          #     package.json to eslint ^10.7.0, but eslint-plugin-react@7.37.5
+          #     peer-supports eslint <= 9, so `npm ci` fails with ERESOLVE. That
+          #     broke every PR here, through no change of ours.
+          #
+          # This is the commit immediately before that bump; `npm ci` and
+          # `webdriver-ts` compile cleanly on it. Bump deliberately after
+          # checking `npm ci` still works, and re-baseline benchmark results
+          # when you do.
+          JFB_COMMIT: 4fbccf556c7c445f414019bc7c15bee0a1860e47
         run: |
           # Remove uninitialized submodule placeholder directory
           rm -rf js-framework-benchmark
-          # Clone upstream benchmark infrastructure (shallow for speed)
-          git clone --depth 1 https://github.com/krausest/js-framework-benchmark.git js-framework-benchmark
+          # Fetch just the pinned commit rather than cloning history.
+          mkdir js-framework-benchmark
+          cd js-framework-benchmark
+          git init -q
+          git remote add origin https://github.com/krausest/js-framework-benchmark.git
+          git fetch --depth 1 origin "$JFB_COMMIT"
+          git checkout -q FETCH_HEAD
+          echo "js-framework-benchmark pinned at $(git rev-parse --short HEAD)"
 
       - name: Setup .NET
         if: steps.should-run.outputs.run == 'true'


### PR DESCRIPTION
### What

The benchmark workflow now fetches a **pinned commit** of `js-framework-benchmark` (`4fbccf55`) instead of cloning whatever upstream HEAD happens to be.

### Why

The `Benchmark (js-framework-benchmark)` check has been failing on every PR that touches a perf path, with an error that has nothing to do with our code:

```
Could not resolve dependency:
peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" from eslint-plugin-react@7.37.5
Conflicting peer dependency: eslint@9.39.5
```

Upstream commit [`89c1c5c1`](https://github.com/krausest/js-framework-benchmark/commit/89c1c5c1) (2026-07-22, *"chore: update eslint and eslint config to latest"*) bumped their root `package.json` to `eslint@^10.7.0`, but `eslint-plugin-react@7.37.5` peer-supports eslint 9 at most. **Their dependency tree does not install.** We were cloning their HEAD unpinned, so we inherited the breakage the moment they pushed it — our CI went red without a single change of ours.

### Why pinning rather than `--legacy-peer-deps`

`--legacy-peer-deps` would silence this specific error and leave the underlying problem: **our CI depends on someone else's moving HEAD.** The next upstream change breaks us again, at a random time, in a way that looks like our regression.

Pinning is also correct on its own merits, independent of this bug: **benchmark numbers are only comparable across runs if the harness is identical.** Tracking HEAD meant the thing doing the measuring could change between two runs we were comparing. The pin was arguably always the right design; this failure just made it urgent.

The pin carries a comment explaining what it is, why it exists, and what to verify before bumping it.

### Testing

Reproduced and verified locally against the real upstream repo:

| Check | HEAD (`247fafa`) | Pinned (`4fbccf55`) |
| --- | --- | --- |
| `npm ci` (root) | ❌ ERESOLVE | ✅ |
| `npm ci` (webdriver-ts) | — | ✅ 364 packages |
| `npm run compile` | — | ✅ |
| root `package.json` eslint | `^10.7.0` | `^9.17.0` |

The `git init` + `git fetch --depth 1 <sha>` + `checkout FETCH_HEAD` sequence was verified standalone against GitHub, so the shallow single-commit fetch works as written.

This PR touches `.github/workflows/benchmark.yml`, which is in the workflow's own `e2e-scripts` path filter — so **this PR triggers a real benchmark run**, and the fix is verified end-to-end by its own CI rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)