### PR TITLE
fix(ci): Align benchmark ids with the pinned harness

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -448,13 +448,13 @@ jobs:
           cd js-framework-benchmark/webdriver-ts
           npm run bench -- --headless --framework keyed/abies --benchmark 01_run1k
           npm run bench -- --headless --framework keyed/abies --benchmark 02_replace1k
-          npm run bench -- --headless --framework keyed/abies --benchmark 03_update10th1k
+          npm run bench -- --headless --framework keyed/abies --benchmark 03_update10th1k_x16
           npm run bench -- --headless --framework keyed/abies --benchmark 04_select1k
           npm run bench -- --headless --framework keyed/abies --benchmark 05_swap1k
           npm run bench -- --headless --framework keyed/abies --benchmark 06_remove-one-1k
           npm run bench -- --headless --framework keyed/abies --benchmark 07_create10k
           npm run bench -- --headless --framework keyed/abies --benchmark 08_create1k-after1k_x2
-          npm run bench -- --headless --framework keyed/abies --benchmark 09_clear1k
+          npm run bench -- --headless --framework keyed/abies --benchmark 09_clear1k_x8
 
       - name: Run Memory benchmarks
         if: steps.should-run.outputs.run == 'true'
@@ -462,7 +462,7 @@ jobs:
           cd js-framework-benchmark/webdriver-ts
           npm run bench -- --headless --framework keyed/abies --benchmark 21_ready-memory
           npm run bench -- --headless --framework keyed/abies --benchmark 22_run-memory
-          npm run bench -- --headless --framework keyed/abies --benchmark 25_clear-memory
+          npm run bench -- --headless --framework keyed/abies --benchmark 25_run-clear-memory
 
       - name: Refresh baseline from gh-pages
         if: steps.should-run.outputs.run == 'true'

--- a/benchmark-results/blazor-baseline.json
+++ b/benchmark-results/blazor-baseline.json
@@ -1,17 +1,17 @@
 {
   "version": "Blazor 10.0",
   "source": "js-framework-benchmark, same-session comparison, March 2026",
-  "notes": "Static baseline — Blazor is not run in CI. Update manually when a new Blazor version ships.",
+  "notes": "Static baseline \u2014 Blazor is not run in CI. Update manually when a new Blazor version ships. Benchmark ids track js-framework-benchmark's own ids (pinned in benchmark.yml); the measurements are unchanged, only the ids were realigned.",
   "duration": {
     "01_run1k": 84.9,
     "02_replace1k": 99.5,
-    "03_update10th1k": 94.5,
+    "03_update10th1k_x16": 94.5,
     "04_select1k": 82.5,
     "05_swap1k": 94.6,
     "06_remove-one-1k": 40.2,
     "07_create10k": 766.1,
     "08_create1k-after1k_x2": 102.9,
-    "09_clear1k": 36.5
+    "09_clear1k_x8": 36.5
   },
   "startup": {
     "first_paint_ms": 78.0,
@@ -21,6 +21,6 @@
   "memory": {
     "21_ready-memory": 41.1,
     "22_run-memory": 52.7,
-    "25_clear-memory": 49.4
+    "25_run-clear-memory": 49.4
   }
 }

--- a/scripts/convert-e2e-results.py
+++ b/scripts/convert-e2e-results.py
@@ -123,19 +123,19 @@ def convert_to_benchmark_format(results: list[dict], memory_only: bool = False) 
         # CPU benchmarks (01-09)
         "01_run1k": "create 1000 rows",
         "02_replace1k": "replace all 1000 rows",
-        "03_update10th1k": "update every 10th row",
+        "03_update10th1k_x16": "update every 10th row",
         "04_select1k": "select row",
         "05_swap1k": "swap two rows",
         "06_remove-one-1k": "remove one row",
         "07_create10k": "create 10,000 rows",
         "08_create1k-after1k_x2": "append 1000 rows",
-        "09_clear1k": "clear all rows",
+        "09_clear1k_x8": "clear all rows",
         # Memory benchmarks (21-26)
         "21_ready-memory": "ready memory",
         "22_run-memory": "run memory",
         "23_update5-memory": "update5 memory",
         "24_replace5-memory": "replace5 memory",
-        "25_clear-memory": "clear memory",
+        "25_run-clear-memory": "clear memory",
         "26_run-clear-memory": "run-clear memory",
         # Startup benchmarks (31-34)
         "31_startup-ci": "startup time",

--- a/scripts/update-readme-benchmarks.py
+++ b/scripts/update-readme-benchmarks.py
@@ -32,19 +32,19 @@ from pathlib import Path
 DURATION_BENCHMARKS = [
     ("01_run1k", "Create 1,000 rows"),
     ("02_replace1k", "Replace 1,000 rows"),
-    ("03_update10th1k", "Update every 10th row ×16"),
+    ("03_update10th1k_x16", "Update every 10th row ×16"),
     ("04_select1k", "Select row"),
     ("05_swap1k", "Swap rows"),
     ("06_remove-one-1k", "Remove row"),
     ("07_create10k", "Create 10,000 rows"),
     ("08_create1k-after1k_x2", "Append 1,000 rows"),
-    ("09_clear1k", "Clear 1,000 rows ×8"),
+    ("09_clear1k_x8", "Clear 1,000 rows ×8"),
 ]
 
 MEMORY_BENCHMARKS = [
     ("21_ready-memory", "Ready memory"),
     ("22_run-memory", "Run memory"),
-    ("25_clear-memory", "Clear memory"),
+    ("25_run-clear-memory", "Clear memory"),
 ]
 
 


### PR DESCRIPTION
Follow-up to #339. With the install fixed, the benchmark job now gets far enough to fail at the *next* step.

### What

Renames three benchmark ids to match what js-framework-benchmark actually emits, in all four places that must agree.

| Ours (stale) | Pinned harness |
| --- | --- |
| `03_update10th1k` | `03_update10th1k_x16` |
| `09_clear1k` | `09_clear1k_x8` |
| `25_clear-memory` | `25_run-clear-memory` |

### Why

```
❌ Missing benchmark data:
  - Missing CI result for duration benchmark: 03_update10th1k (Update every 10th row ×16)
  - Missing CI result for duration benchmark: 09_clear1k (Clear 1,000 rows ×8)
  - Missing CI result for memory benchmark: 25_clear-memory (Clear memory)
```

Our **labels** already said "×16" and "×8" — only the **ids** were left behind, which is the signature of a partial rename that went unnoticed because the job had been dying earlier at `npm ci`.

I confirmed the correct names against `webdriver-ts/src/benchmarksCommon.ts` at the pinned commit rather than inferring them from the error message, and cross-checked that all 12 ids the README script expects now exist in the harness.

**All four files have to move together.** The README script looks up the CI result *and* the Blazor reference by the same key, so renaming the workflow and scripts without `blazor-baseline.json` would just trade `Missing CI result` for `Missing Blazor baseline`. The Blazor measurements themselves are unchanged — only their keys move, and the baseline's `notes` field now records that.

### One thing worth knowing

Two of the stale ids (`03_update10th1k`, `09_clear1k`) happened to **prefix-match** and ran anyway, writing results under the full name — which is why only the README step noticed. `25_clear-memory` matched nothing, and the runner **exited cleanly having measured nothing**:

```
> node dist/benchmarkRunner.js --headless --framework keyed/abies --benchmark 25_clear-memory
  benchmark: [ '25_clear-memory' ],
```

No error, no result. An unrecognised benchmark id is silent, so a typo here costs a metric rather than a red build.

### On the baseline

Re-baselining turned out to be unnecessary — **it already self-healed.** Once #339 let the job run, main's push run reported `✅ No regressions detected` and published a fresh baseline to `gh-pages` (`7a0feb6`). The stale March numbers I flagged were an artifact of the workflow's refresh step never being reached while the install was broken.

### Testing

- All four files validate: JSON parses, YAML parses, both Python scripts compile.
- Cross-checked the script's 12 expected ids against the pinned harness's definitions — **none missing**.
- This PR touches `benchmark.yml`, which is in the workflow's own `e2e-scripts` filter, so it triggers a **real benchmark run** and is verified end-to-end by its own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)