### PR TITLE
fix(ci): Don't fail the benchmark job when the README PR can't be opened

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -640,7 +640,16 @@ jobs:
             --readme README.md \
             --framework abies
 
+      # Opening the README PR is a convenience, not part of measuring anything.
+      # It needs "Allow GitHub Actions to create and approve pull requests"
+      # (Settings → Actions → General); without it the action fails with
+      # "GitHub Actions is not permitted to create or approve pull requests".
+      # That is a repository setting, so failing the benchmark job over it would
+      # report a permissions gap as a performance problem. The next step says
+      # plainly what to enable if it is skipped.
       - name: Create PR for README benchmark updates (main only)
+        id: readme-pr
+        continue-on-error: true
         if: steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
@@ -655,6 +664,18 @@ jobs:
           base: main
           add-paths: |
             README.md
+
+      - name: Note if the README PR could not be opened
+        if: steps.readme-pr.outcome == 'failure'
+        run: |
+          echo "::warning::Benchmarks ran and compared fine, but the README update PR could not be opened."
+          echo "::warning::Enable Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests', or update README.md by hand."
+          {
+            echo "### README update PR not created"
+            echo ""
+            echo "Benchmarks ran and compared successfully; only the follow-up PR was blocked."
+            echo "Enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** to restore it."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Copy results to workspace for upload
         if: always() && steps.should-run.outputs.run == 'true'


### PR DESCRIPTION
Last step of getting the benchmark job green.

### What

The "Create PR for README benchmark updates" step is now `continue-on-error`, followed by a step that reports what to enable if it was skipped.

### Why

After #339, #340 and #341 the benchmark pipeline runs clean end to end on `main` — install, benchmark, comparison (`✅ No regressions detected`, all 12 metrics), baseline refresh. Then the job failed on this:

```
GitHub Actions is not permitted to create or approve pull requests.
```

That's the repository setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**, not anything about performance. It cannot be fixed from a workflow file — only a repo admin can enable it.

Failing the benchmark check over it reports a permissions gap as a performance problem. That's the same misattribution the threshold work in #341 was about: a red benchmark should mean the code got slower, otherwise people learn to ignore it.

Opening the README PR is a convenience *after* the measuring is done, so it no longer gates the result. It's not silently swallowed either — if it's skipped you get a workflow warning and a job-summary note naming the exact setting.

### Your call

If you'd rather the automation keep working, enable that setting and this step resumes opening PRs — the `continue-on-error` becomes a no-op. Otherwise README benchmark tables need updating by hand, which the warning says.

### Also still failing on main, unrelated

`Micro-Benchmarks (main only)` fails with:

```
Nerdbank.GitVersioning: Shallow clone lacks the objects required to calculate version height
```

That's a checkout-depth problem in a different job (it needs `fetch-depth: 0`), pre-existing and untouched here. Happy to fix it separately if you want.

### Testing

`benchmark.yml` parses; step wiring verified (`continue-on-error=True`, `id=readme-pr`, and the reporting step keyed off `steps.readme-pr.outcome`). The step only runs on `main` pushes, so this PR's own run exercises the rest of the pipeline rather than this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)