### PR TITLE
fix(ci): Give Micro-Benchmarks the full history Nerdbank.GitVersioning needs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -121,6 +121,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Nerdbank.GitVersioning walks history to compute version height, so a
+          # shallow clone fails the build outright with "Shallow clone lacks the
+          # objects required to calculate version height". Every other checkout
+          # in this repo already sets this.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
The last red job on `main`.

### What

Adds `fetch-depth: 0` to the `Micro-Benchmarks (main only)` checkout.

### Why

```
Nerdbank.GitVersioning.GitException: Shallow clone lacks the objects required to
calculate version height. Use full clones or clones with a history at least as
deep as the last version height resetting change.
 ---> An commit object with SHA f4260a7446... could not be found.
```

NBGV walks history to compute version height, so `actions/checkout`'s default shallow clone can't work. That checkout was **the only one in the repo without `fetch-depth: 0`** — the other 23 already set it, including the e2e benchmark job in this same file. It looks like a step that was added later and missed the convention.

The project itself is fine: `dotnet build Picea.Abies.Benchmarks -c Release` is clean locally, where history is complete. The failure was purely the checkout depth.

### Testing

- `benchmark.yml` parses; verified `benchmark: fetch-depth=0` alongside the already-correct `benchmark-check`.
- `Picea.Abies.Benchmarks` builds 0 warnings / 0 errors locally.
- **This job only runs on pushes to `main`** (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`), so this PR's CI cannot exercise it. I'll confirm on the main run after merge and report back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)