### PR TITLE
ci(benchmark): Publish README updates as a branch, not a PR

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -646,42 +646,67 @@ jobs:
             --readme README.md \
             --framework abies
 
-      # Opening the README PR is a convenience, not part of measuring anything.
-      # It needs "Allow GitHub Actions to create and approve pull requests"
-      # (Settings → Actions → General); without it the action fails with
-      # "GitHub Actions is not permitted to create or approve pull requests".
-      # That is a repository setting, so failing the benchmark job over it would
-      # report a permissions gap as a performance problem. The next step says
-      # plainly what to enable if it is skipped.
-      - name: Create PR for README benchmark updates (main only)
-        id: readme-pr
+      # This deliberately pushes a branch rather than opening a PR. Creating PRs
+      # from Actions requires "Allow GitHub Actions to create and approve pull
+      # requests", which is disabled here on purpose; pushing a branch needs only
+      # the contents: write this workflow already uses for gh-pages. The result is
+      # a ready-to-review diff plus a one-click link, with a human opening the PR.
+      - name: Push README benchmark updates to a branch (main only)
+        id: readme-branch
         continue-on-error: true
         if: steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "docs: update benchmark results in README"
-          title: "docs: update benchmark results in README"
-          body: |
-            Automated update of benchmark tables in README.md based on the latest js-framework-benchmark results.
-
-            This PR was created by the Benchmark workflow after running on `main`.
-          branch: benchmark/readme-auto-update
-          base: main
-          add-paths: |
-            README.md
-
-      - name: Note if the README PR could not be opened
-        if: steps.readme-pr.outcome == 'failure'
+        env:
+          README_BRANCH: benchmark/readme-auto-update
         run: |
-          echo "::warning::Benchmarks ran and compared fine, but the README update PR could not be opened."
-          echo "::warning::Enable Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests', or update README.md by hand."
-          {
-            echo "### README update PR not created"
-            echo ""
-            echo "Benchmarks ran and compared successfully; only the follow-up PR was blocked."
-            echo "Enable **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** to restore it."
-          } >> "$GITHUB_STEP_SUMMARY"
+          if git diff --quiet -- README.md; then
+            echo "README benchmark tables are already up to date; nothing to push."
+            echo "readme_changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "readme_changed=true" >> "$GITHUB_OUTPUT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Commit only README.md — the workspace also holds benchmark artifacts.
+          git checkout -b "$README_BRANCH"
+          git add README.md
+          git commit -m "docs: update benchmark results in README"
+
+          # Force-push: this branch is regenerated from main on every run and is
+          # not meant to be worked on by hand.
+          git push --force origin "$README_BRANCH"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Report README branch status
+        if: always() && steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          README_BRANCH: benchmark/readme-auto-update
+        run: |
+          if [ "${{ steps.readme-branch.outputs.readme_changed }}" != "true" ]; then
+            echo "### README benchmark tables unchanged" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          COMPARE="${{ github.server_url }}/${{ github.repository }}/compare/main...${README_BRANCH}?expand=1"
+
+          if [ "${{ steps.readme-branch.outputs.pushed }}" = "true" ]; then
+            echo "::notice::README benchmark tables changed — open a PR from ${README_BRANCH}: ${COMPARE}"
+            {
+              echo "### README benchmark tables updated"
+              echo ""
+              echo "Pushed to \`${README_BRANCH}\`. Actions cannot open PRs in this repository, so review and merge it here:"
+              echo ""
+              echo "[Open pull request]($COMPARE)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::README benchmark tables changed but the branch could not be pushed; update README.md by hand."
+            {
+              echo "### README branch could not be pushed"
+              echo ""
+              echo "Benchmarks ran and compared successfully; only publishing the README diff failed."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Copy results to workspace for upload
         if: always() && steps.should-run.outputs.run == 'true'


### PR DESCRIPTION
Since "Allow GitHub Actions to create and approve pull requests" is disabled — and keeping it that way is a reasonable posture — the workflow shouldn't depend on it.

### What

Replaces `peter-evans/create-pull-request` with a plain branch push. The workflow pushes the README benchmark update to `benchmark/readme-auto-update` and puts a one-click compare link in the job summary; you open the PR.

### Why this works without the setting

Pushing a branch needs only the `contents: write` this workflow **already uses** to publish baselines and trends to `gh-pages` — demonstrably working, since that's how the baseline lands there each run. Only *PR creation* was blocked.

So nothing has to be enabled, and the human review step is unchanged — it just starts from a link instead of a bot-authored PR.

### Details

- **Only `README.md` is committed.** The workspace also holds benchmark artifacts at that point (`benchmark-results/`, converted result JSON), and they must not be swept in.
- **The push is forced.** That branch is regenerated from `main` every run and isn't meant to be worked on by hand.
- **An unchanged README skips the push** rather than creating an empty branch, and says so in the summary — no churn on runs where numbers didn't move enough to change the tables.
- **Publishing stays `continue-on-error`** with an explicit warning. The job's purpose is measuring; failing to publish a docs diff shouldn't be reported as a performance regression.

`pull-requests: write` is left in the permissions block — `comment-on-alert` may still need it, and trimming it isn't worth a speculative regression.

### Testing

- `benchmark.yml` parses; step wiring verified (`id=readme-branch`, `continue-on-error=True`, reporting step keyed off its outputs).
- The git sequence was simulated in a scratch repo with the same workspace shape (modified `README.md` plus untracked benchmark artifacts):
  - commits **`README.md` only** ✅
  - artifacts left untouched ✅
  - lands on `benchmark/readme-auto-update` ✅
  - **unchanged README correctly skips** ✅
- These steps only run on pushes to `main`, so this PR's own CI can't exercise them — I'll confirm on the main run after merge, as with #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)