### PR TITLE
ci(benchmark): Stop auto-updating the README comparison tables

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -637,76 +637,20 @@ jobs:
       # Opens a PR instead of pushing directly to main to avoid triggering other
       # on:push workflows (CD, E2E, etc.).
       # ============================================================================
-      - name: Update README benchmark tables (main only)
-        if: steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          python3 scripts/update-readme-benchmarks.py \
-            --results-dir js-framework-benchmark/webdriver-ts/results \
-            --blazor-baseline benchmark-results/blazor-baseline.json \
-            --readme README.md \
-            --framework abies
-
-      # This deliberately pushes a branch rather than opening a PR. Creating PRs
-      # from Actions requires "Allow GitHub Actions to create and approve pull
-      # requests", which is disabled here on purpose; pushing a branch needs only
-      # the contents: write this workflow already uses for gh-pages. The result is
-      # a ready-to-review diff plus a one-click link, with a human opening the PR.
-      - name: Push README benchmark updates to a branch (main only)
-        id: readme-branch
-        continue-on-error: true
-        if: steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          README_BRANCH: benchmark/readme-auto-update
-        run: |
-          if git diff --quiet -- README.md; then
-            echo "README benchmark tables are already up to date; nothing to push."
-            echo "readme_changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "readme_changed=true" >> "$GITHUB_OUTPUT"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Commit only README.md — the workspace also holds benchmark artifacts.
-          git checkout -b "$README_BRANCH"
-          git add README.md
-          git commit -m "docs: update benchmark results in README"
-
-          # Force-push: this branch is regenerated from main on every run and is
-          # not meant to be worked on by hand.
-          git push --force origin "$README_BRANCH"
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Report README branch status
-        if: always() && steps.should-run.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          README_BRANCH: benchmark/readme-auto-update
-        run: |
-          if [ "${{ steps.readme-branch.outputs.readme_changed }}" != "true" ]; then
-            echo "### README benchmark tables unchanged" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          COMPARE="${{ github.server_url }}/${{ github.repository }}/compare/main...${README_BRANCH}?expand=1"
-
-          if [ "${{ steps.readme-branch.outputs.pushed }}" = "true" ]; then
-            echo "::notice::README benchmark tables changed — open a PR from ${README_BRANCH}: ${COMPARE}"
-            {
-              echo "### README benchmark tables updated"
-              echo ""
-              echo "Pushed to \`${README_BRANCH}\`. Actions cannot open PRs in this repository, so review and merge it here:"
-              echo ""
-              echo "[Open pull request]($COMPARE)"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::warning::README benchmark tables changed but the branch could not be pushed; update README.md by hand."
-            {
-              echo "### README branch could not be pushed"
-              echo ""
-              echo "Benchmarks ran and compared successfully; only publishing the README diff failed."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+      # The README's benchmark tables are maintained by hand, on purpose.
+      #
+      # That table is a *same-session* comparison — Abies and Blazor measured on
+      # the same machine in the same sitting — which is the only reason its
+      # Delta column means anything. Blazor is not run in CI, so an automated
+      # update could only replace the Abies column with numbers from a shared
+      # runner while leaving Blazor's local numbers in place. It did exactly
+      # that once: Create 1,000 rows went from 119.5ms (+34% vs Blazor) to
+      # 331.8ms (+291%), which measured the gap between a CI runner and a
+      # laptop and attributed it to the framework.
+      #
+      # CI's valid contribution is the Abies-over-time trend, which is published
+      # to gh-pages above and is unaffected by this. Refresh the README with a
+      # local same-session run using scripts/update-readme-benchmarks.py.
 
       - name: Copy results to workspace for upload
         if: always() && steps.should-run.outputs.run == 'true'

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Latest same-session validation (2026-04-02, AC power, local main baseline):
 
 Details: [Render StringBuilder Pool Cap Validation (2026-04-02)](docs/investigations/render-stringbuilder-pool-cap-validation-2026-04-02.md)
 
+> **These tables are updated by hand, from a local same-session run.** Both
+> frameworks must be measured on the same machine in the same sitting, or the
+> Delta column compares machines rather than frameworks. CI tracks Abies over
+> time instead — see the [benchmark trends](https://picea.github.io/Abies/) —
+> and deliberately does not touch these tables. To refresh them, run both suites
+> locally and then `scripts/update-readme-benchmarks.py`.
+
 <!-- BENCHMARK:DURATION:START -->
 | Benchmark | Abies 2.1 | Blazor 10.0 | Delta |
 | --- | --- | --- | --- |

--- a/scripts/update-readme-benchmarks.py
+++ b/scripts/update-readme-benchmarks.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
 """
-Update README.md benchmark tables with latest CI results.
+Update README.md benchmark tables from a local same-session benchmark run.
 
 Reads js-framework-benchmark result files and a static Blazor baseline,
 then regenerates the benchmark comparison tables in README.md between
 HTML comment markers.
 
+RUN THIS LOCALLY, NOT IN CI.
+
+The README table is a same-session comparison: Abies and Blazor measured on the
+same machine in the same sitting. That is the only reason its Delta column means
+anything. Blazor is not run in CI, so running this against CI results replaces
+the Abies column with shared-runner numbers while leaving Blazor's local numbers
+in place, and the Delta then reports the difference between two machines as if it
+were a difference between two frameworks. It was briefly wired into the benchmark
+workflow and did exactly that: Create 1,000 rows went from 119.5ms (+34% vs
+Blazor) to 331.8ms (+291%).
+
+So: measure Abies and Blazor in one local session, then run this. CI's valid
+contribution is the Abies-over-time trend published to gh-pages, which does not
+involve this script.
+
 Only updates Duration (01-09) and Memory (21, 22, 25) tables.
-Startup/Size is not measured in CI and stays static.
+Startup/Size is not measured here and stays static.
 
 Usage:
     python scripts/update-readme-benchmarks.py \\


### PR DESCRIPTION
### What

Removes the three README auto-update steps from the benchmark workflow. The tables go back to being maintained by hand, which is what their methodology requires.

### Why

The README's benchmark tables are a **same-session** comparison — Abies and Blazor measured on the same machine in the same sitting. That's the only reason the Delta column means anything, and both the README and `blazor-baseline.json` say so:

> Measured with js-framework-benchmark **on the same machine, same session**.

> *"Static baseline — Blazor is not run in CI."*

CI structurally cannot produce a comparable figure. Blazor isn't run there, so the automated update could only swap the Abies column for shared-runner numbers while leaving Blazor's local numbers in place. On its first successful run it did exactly that:

| Benchmark | README (same-session) | CI-generated |
| --- | --- | --- |
| Create 1,000 rows | 119.5 ms (**+34%** vs Blazor) | 331.8 ms (**+291%**) |
| Create 10,000 rows | 1183.5 ms (**+47%**) | 3342.4 ms (**+336%**) |

Those deltas are the gap between a CI runner and a laptop, published as if the framework had regressed 4×. Merging that would have been worse than publishing nothing — it's a wrong number wearing the authority of automation.

It's the same error as the baseline problem in #341, one layer up: **comparability requires holding the measurement environment fixed.** #341 fixed it for CI-vs-CI; this fixes it for the README's local-vs-local.

### What still works

Nothing of value is lost. CI's valid contribution is Abies measured against its own history:

- the Abies-over-time trend still publishes to `gh-pages`
- the regression gate still compares CI against CI, with the smoothed baseline and 25% threshold from #341
- micro-benchmark throughput/allocation baselines still publish

Only the cross-framework table — which CI was never able to produce honestly — is no longer touched.

### Guardrails against re-adding it

- The reasoning is left **in the workflow** at the point where the steps used to be, with the actual numbers, so the next person sees why rather than re-adding it.
- `scripts/update-readme-benchmarks.py` stays as a local tool and its docstring now opens with **"RUN THIS LOCALLY, NOT IN CI"** plus the failure it causes.
- The README gains a short note that the tables are hand-maintained and why, pointing at the trends page for CI data.

### Follow-up for you

The stale `benchmark/readme-auto-update` branch still exists with that misleading diff on it. Worth deleting so nobody merges it later — say the word and I'll remove it, or delete it from the branches page.

### Testing

- `benchmark.yml` parses; the three README steps are gone (28 steps remain in `benchmark-check`, none matching README).
- No dangling references: nothing in `.github/` or `scripts/` invokes the removed steps.
- `update-readme-benchmarks.py` compiles and `--help` works — still usable locally.
- `DocSnippetCheck`: 31 compiled, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)