### PR TITLE
chore(release): Bump version.json to 2.3

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.2"
+    "version": "2.3"
 }


### PR DESCRIPTION
### What

Bumps `version.json` from `2.2` to `2.3` ahead of tagging `v2.3.0`.

### Why

32 commits since `v2.2.0`, headlined by the **native WinUI renderer** — control vocabulary and patch interpreter, a WinUI 3 backend on both Windows App SDK and Uno Skia heads, the `Program` Core/View split, two analyzer rules, two samples, and an `abies-native` template.

**Minor, not major.** The Core/View split is additive — `Program` requires the same members it always did — and was verified against 496 tests with no source changes outside the native sample. The one `!` commit in the range (the native value-enum rename) is inside a package that has never shipped, so it breaks nobody.

**Six package IDs publish for the first time** at this version: `Picea.Abies.Native`, `.WinUI`, `.Testing`, `.Testing.Visual`, `.UI`, `.Cli`.

### Testing

Version-only change. I'll dry-run the full release workflow via `workflow_dispatch` before tagging — the publish step is gated on a `refs/tags/v*` ref, so a dispatch run packs everything without pushing to NuGet. That matters here because the `pack-winui` job added in #333 has never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)