### PR TITLE
fix(release): Stamp the WinUI package with the tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,21 @@ jobs:
       - name: Install GitVersioning
         run: dotnet tool install --global nbgv
 
+      # Must mirror the release job exactly. Passing /p:Version alone is not
+      # enough: Nerdbank.GitVersioning overrides it and stamps a dev version, so
+      # v2.3.0 produced Picea.Abies.WinUI 2.3.1-gbb31d7ec9b while every other
+      # package was 2.3.0. `nbgv set-version` plus PublicRelease=true is what
+      # makes the tag version stick and drops the -g<hash> suffix.
       - name: Set version
         id: version
         shell: bash
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+            nbgv set-version "$VERSION"
+            echo "PublicRelease=true" >> "$GITHUB_ENV"
           else
-            VERSION=$(nbgv get-version -v NuGetPackageVersion)
+            VERSION=$(nbgv get-version -v SimpleVersion)
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Packing Picea.Abies.WinUI as $VERSION"
@@ -49,8 +56,10 @@ jobs:
       - name: Pack Picea.Abies.WinUI (Skia + Windows App SDK heads)
         run: dotnet pack ./Picea.Abies.WinUI/Picea.Abies.WinUI.csproj --configuration Release --output ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
 
-      - name: Verify both target frameworks are in the package
+      - name: Verify the package version and target frameworks
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           PKG=$(ls ./nupkg/Picea.Abies.WinUI.*.nupkg | head -1)
           echo "Inspecting $PKG"
@@ -61,6 +70,17 @@ jobs:
           grep -q "lib/net10.0-windows10.0.26100" /tmp/pkg-listing.txt \
             || { echo "❌ Package is missing the Windows App SDK head"; exit 1; }
           echo "✅ Windows App SDK head present"
+
+          # This job packs on a different runner from the rest of the release, so
+          # its version has to be checked rather than assumed — a mismatch here
+          # publishes one package at a different version from all the others.
+          case "$(basename "$PKG")" in
+            "Picea.Abies.WinUI.${EXPECTED_VERSION}.nupkg")
+              echo "✅ Package version matches the release ($EXPECTED_VERSION)" ;;
+            *)
+              echo "❌ Expected Picea.Abies.WinUI.${EXPECTED_VERSION}.nupkg, got $(basename "$PKG")"
+              exit 1 ;;
+          esac
 
       - name: Upload WinUI package
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What

Makes the Windows pack job stamp the tag version, and asserts it did.

### Why

`v2.3.0` published **thirteen packages as `2.3.0`** and **`Picea.Abies.WinUI` as `2.3.1-gbb31d7ec9b`** — a prerelease. So `dotnet add package Picea.Abies.WinUI` resolves nothing stable, and `2.3.0` of the flagship native package doesn't exist.

The Windows job passed `/p:Version=2.3.0` and assumed that was enough. It isn't — **Nerdbank.GitVersioning overrides `/p:Version`** and stamps its own dev version. The Linux release job already knew this:

```bash
VERSION="${GITHUB_REF#refs/tags/v}"
nbgv set-version "$VERSION"
echo "PublicRelease=true" >> "$GITHUB_ENV"
```

`nbgv set-version` plus `PublicRelease=true` is what makes the tag version stick and drops the `-g<hash>` suffix. The Windows job now mirrors it exactly.

### Why the dry run missed it

I dry-ran the release via `workflow_dispatch` before tagging, and it passed. On a non-tag ref **both** the correct and incorrect paths produce a dev version — so the bug was invisible precisely because the dry run wasn't a tag. Worth remembering: a dispatch dry run validates the mechanics, not the version stamping.

### The guard that would have caught it

The verification step now checks the produced **filename against the expected version**, not just that the Windows head is present:

```bash
case "$(basename "$PKG")" in
  "Picea.Abies.WinUI.${EXPECTED_VERSION}.nupkg") echo "✅ ..." ;;
  *) echo "❌ Expected ...${EXPECTED_VERSION}.nupkg, got $(basename "$PKG")"; exit 1 ;;
esac
```

This job packs on a **different runner** from the rest of the release, so its version has to be checked rather than assumed — that gap is exactly what shipped a mismatched package. It fails before upload, so a future mismatch blocks the release rather than publishing into it.

### Recommended follow-up

Tag **`v2.3.1`** once this merges, so `Picea.Abies.WinUI 2.3.1` exists as a stable version alongside the rest. `2.3.1-gbb31d7ec9b` is a prerelease of `2.3.1`, so a real `2.3.1` supersedes it cleanly — no need to unlist anything, though you may want to unlist the prerelease to avoid confusion.

The other thirteen packages at `2.3.0` are correct and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)