### PR TITLE
fix(release): Only assert the WinUI package version on tag refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,15 @@ jobs:
           # This job packs on a different runner from the rest of the release, so
           # its version has to be checked rather than assumed — a mismatch here
           # publishes one package at a different version from all the others.
+          #
+          # Only meaningful on a tag. On other refs nothing is published, and
+          # NuGetVersion legitimately carries a -g<hash> suffix that SimpleVersion
+          # does not, so comparing them would fail every dry run.
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "ℹ️  Not a tag ref — skipping the version assertion (nothing is published)."
+            exit 0
+          fi
+
           case "$(basename "$PKG")" in
             "Picea.Abies.WinUI.${EXPECTED_VERSION}.nupkg")
               echo "✅ Package version matches the release ($EXPECTED_VERSION)" ;;


### PR DESCRIPTION
### What

Scopes the WinUI package-version assertion (added in #349) to tag refs.

### Why

As written it would fail **every `workflow_dispatch` dry run**. On a non-tag ref the step compares `SimpleVersion` (`2.3.1`) against a filename that legitimately carries `NuGetVersion`'s dev suffix (`2.3.1-g5486420.nupkg`), so it would always mismatch.

That matters because the dispatch dry run is the mechanism I used to validate the release before tagging `v2.3.0` — breaking it would remove the safety net while trying to add one.

Nothing is published off a tag, so the check is skipped there and says so. On a tag — the only case where a mismatch can actually ship — it still fails before upload.

### Testing

`release.yml` parses. The tag path is unchanged; only the non-tag path gains an early exit.

Caught by re-reading the step before tagging `v2.3.1`, rather than by a dry run — which is fitting, given a dry run is exactly what it would have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)