### PR TITLE
fix(tests): Publish once per project in the release-output probe

### DIFF
--- a/Picea.Abies.Tests/Debugger/PublishOutputProbe.cs
+++ b/Picea.Abies.Tests/Debugger/PublishOutputProbe.cs
@@ -1,10 +1,42 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 
 namespace Picea.Abies.Tests.Debugger;
 
+/// <summary>
+/// Publishes a project once per test run so release-output assertions can
+/// inspect the result.
+/// </summary>
+/// <remarks>
+/// Two things here are load-bearing, and both exist because this probe caused a
+/// recurring CI failure:
+///
+/// <para>
+/// <b>One publish per project.</b> Several tests assert against the same
+/// published output and the runner executes them in parallel. Each call used to
+/// start its own <c>dotnet publish</c>, so two MSBuild processes wrote the same
+/// files concurrently and one lost:
+/// <c>The process cannot access the file 'Picea.Abies.deps.json' because it is
+/// being used by another process</c>. Results are now memoized per project, so
+/// the publish happens once however many tests ask for it — which is also
+/// faster.
+/// </para>
+///
+/// <para>
+/// <b>Why not also redirect bin/obj.</b> Sending intermediates elsewhere with
+/// <c>BaseIntermediateOutputPath</c> looks tidier but breaks the build: the SDK
+/// excludes the *configured* intermediate directory from source globs, so the
+/// repository's own <c>obj/</c> stops being excluded and its generated
+/// <c>Picea.Abies.Version.cs</c> gets compiled a second time (CS0579, duplicate
+/// assembly attributes). Serializing the publish is enough on its own.
+/// </para>
+/// </remarks>
 internal static class PublishOutputProbe
 {
+    private static readonly ConcurrentDictionary<string, Lazy<Task<string>>> _publishes =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public static string ResolveRepositoryRoot()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);
@@ -22,7 +54,22 @@ internal static class PublishOutputProbe
         throw new InvalidOperationException("Could not resolve repository root for publish probe.");
     }
 
-    public static async Task<string> PublishReleaseProject(string projectRelativePath, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Publishes <paramref name="projectRelativePath"/> in Release and returns the
+    /// output directory. Concurrent callers share a single publish.
+    /// </summary>
+    public static Task<string> PublishReleaseProject(string projectRelativePath, CancellationToken cancellationToken = default)
+    {
+        // LazyThreadSafetyMode is the default for Lazy<T>, so only the first
+        // caller starts the process; the rest await the same task.
+        var publish = _publishes.GetOrAdd(
+            projectRelativePath,
+            key => new Lazy<Task<string>>(() => PublishOnce(key, cancellationToken)));
+
+        return publish.Value;
+    }
+
+    private static async Task<string> PublishOnce(string projectRelativePath, CancellationToken cancellationToken)
     {
         var repositoryRoot = ResolveRepositoryRoot();
         var projectPath = Path.Combine(repositoryRoot, projectRelativePath);


### PR DESCRIPTION
### What

Memoizes `PublishOutputProbe.PublishReleaseProject` so a project is published once per test run, however many tests ask for it.

### Why

This is the source of the `GenerateDepsFile` file-lock failure that has been intermittently breaking CI — four times in recent memory — and it **blocked the `v2.3.1` release**:

```
The "GenerateDepsFile" task failed unexpectedly.
System.IO.IOException: The process cannot access the file
'Picea.Abies/bin/Release/net10.0/Picea.Abies.deps.json'
because it is being used by another process.
```

`DebuggerReleaseStripTests` calls the probe from **two** tests, and the runner executes them **in parallel**. Each call started its own `dotnet publish` of the same project, so two MSBuild processes wrote the same output concurrently and one lost.

Nothing about it was CI-specific — it was a coin flip that faster local machines usually won, which is why it looked like infrastructure flakiness rather than a bug in our own test helper.

### Evidence

Counting the temp publish directories a run creates (one per `dotnet publish`):

| | Publishes |
| --- | --- |
| Before | **2** |
| After | **1** |

The full 224-test suite now passes three times consecutively; it previously failed roughly one run in four. It's also faster — the second publish was pure duplicated work.

### An approach I tried and rejected

Redirecting `BaseOutputPath`/`BaseIntermediateOutputPath` into the temp directory looks tidier — the probe would stop writing into the repository's `bin/obj` at all. It breaks the build:

```
Picea.Abies/obj/Debug/net10.0/Picea.Abies.Version.cs(13,12):
error CS0579: Duplicate 'AssemblyVersionAttribute' attribute
```

The SDK excludes the *configured* intermediate directory from source globs. Point it elsewhere and the repository's own `obj/` stops being excluded, so NBGV's generated `Version.cs` gets compiled a second time. Serializing the publish is sufficient on its own, and that reasoning is recorded on the class so it isn't retried.

### Testing

- `DebuggerReleaseStripTests` 5/5
- Full `Picea.Abies.Tests` suite: **224/224, three consecutive runs**
- Publish-invocation count verified before and after by stashing the fix
- `dotnet format --verify-no-changes` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)