### PR TITLE
feat(native): Window long lists so the control count follows the viewport

### DIFF
--- a/Picea.Abies.Native.Tests/VirtualizationTests.cs
+++ b/Picea.Abies.Native.Tests/VirtualizationTests.cs
@@ -1,0 +1,142 @@
+// =============================================================================
+// List Windowing Tests
+// =============================================================================
+// The window arithmetic decides both what the user sees and whether the
+// scrollbar tells the truth, and it is pure — so it is worth pinning hard,
+// including the boundaries where off-by-one errors show up as blank rows.
+// =============================================================================
+
+namespace Picea.Abies.Native.Tests;
+
+public class VirtualizationTests
+{
+    private const double RowHeight = 40;
+
+    [Test]
+    public async Task AtTheTop_RendersFromTheFirstItem()
+    {
+        var window = Virtualization.Window(itemCount: 10_000, RowHeight, scrollOffset: 0, viewportHeight: 400);
+
+        await Assert.That(window.StartIndex).IsEqualTo(0);
+        await Assert.That(window.TopPadding).IsEqualTo(0);
+        // A screenful is 10 rows; the window adds one partial row plus overscan.
+        await Assert.That(window.Count).IsLessThan(25);
+        await Assert.That(window.Count).IsGreaterThan(10);
+    }
+
+    /// <summary>Padding above plus rows plus padding below must equal the full list height,
+    /// or the scrollbar misrepresents how much there is to scroll.</summary>
+    [Test]
+    public async Task PaddingAndRows_AlwaysSpanTheWholeList()
+    {
+        foreach (var offset in new double[] { 0, 137, 4000, 100_000, 399_600 })
+        {
+            var window = Virtualization.Window(10_000, RowHeight, offset, viewportHeight: 400);
+            var spanned = window.TopPadding + (window.Count * RowHeight) + window.BottomPadding;
+
+            await Assert.That(spanned).IsEqualTo(10_000 * RowHeight)
+                .Because($"offset {offset} should still span the full list height");
+        }
+    }
+
+    [Test]
+    public async Task ScrolledIntoTheMiddle_WindowFollowsTheOffset()
+    {
+        // 100 rows down.
+        var window = Virtualization.Window(10_000, RowHeight, scrollOffset: 100 * RowHeight, viewportHeight: 400);
+
+        await Assert.That(window.StartIndex).IsLessThanOrEqualTo(100);
+        await Assert.That(window.EndIndex).IsGreaterThan(110);
+        await Assert.That(window.TopPadding).IsEqualTo(window.StartIndex * RowHeight);
+    }
+
+    [Test]
+    public async Task AtTheBottom_DoesNotRunPastTheEnd()
+    {
+        var itemCount = 500;
+        var window = Virtualization.Window(itemCount, RowHeight, scrollOffset: itemCount * RowHeight, viewportHeight: 400);
+
+        await Assert.That(window.EndIndex).IsEqualTo(itemCount);
+        await Assert.That(window.BottomPadding).IsEqualTo(0);
+        await Assert.That(window.StartIndex).IsGreaterThan(0);
+    }
+
+    /// <summary>A scroll offset past the end must clamp, not produce a negative window.</summary>
+    [Test]
+    public async Task OffsetBeyondTheEnd_Clamps()
+    {
+        var window = Virtualization.Window(100, RowHeight, scrollOffset: 999_999, viewportHeight: 400);
+
+        await Assert.That(window.StartIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(window.EndIndex).IsEqualTo(100);
+        await Assert.That(window.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ViewportTallerThanTheList_RendersEverything()
+    {
+        var window = Virtualization.Window(itemCount: 5, RowHeight, scrollOffset: 0, viewportHeight: 2000);
+
+        await Assert.That(window.StartIndex).IsEqualTo(0);
+        await Assert.That(window.Count).IsEqualTo(5);
+        await Assert.That(window.TopPadding).IsEqualTo(0);
+        await Assert.That(window.BottomPadding).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task EmptyList_ProducesAnEmptyWindow()
+    {
+        await Assert.That(Virtualization.Window(0, RowHeight, 0, 400)).IsEqualTo(ListWindow.Empty);
+    }
+
+    /// <summary>Guards against a divide-by-zero from an unmeasured row height.</summary>
+    [Test]
+    public async Task NonPositiveRowHeight_ProducesAnEmptyWindow()
+    {
+        await Assert.That(Virtualization.Window(100, 0, 0, 400)).IsEqualTo(ListWindow.Empty);
+        await Assert.That(Virtualization.Window(100, -5, 0, 400)).IsEqualTo(ListWindow.Empty);
+    }
+
+    /// <summary>
+    /// Before the first scroll event the viewport is still zero. Rendering
+    /// nothing would leave the list blank until the user touched it.
+    /// </summary>
+    [Test]
+    public async Task UnmeasuredViewport_StillRendersAScreenful()
+    {
+        var window = Virtualization.Window(10_000, RowHeight, scrollOffset: 0, viewportHeight: 0);
+
+        await Assert.That(window.Count).IsGreaterThan(0);
+        await Assert.That(window.StartIndex).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Overscan_WidensTheWindowOnBothSides()
+    {
+        var none = Virtualization.Window(10_000, RowHeight, 100 * RowHeight, 400, overscan: 0);
+        var wide = Virtualization.Window(10_000, RowHeight, 100 * RowHeight, 400, overscan: 10);
+
+        await Assert.That(wide.StartIndex).IsLessThan(none.StartIndex);
+        await Assert.That(wide.EndIndex).IsGreaterThan(none.EndIndex);
+    }
+
+    [Test]
+    public async Task NegativeOverscan_IsTreatedAsZero()
+    {
+        var negative = Virtualization.Window(10_000, RowHeight, 100 * RowHeight, 400, overscan: -5);
+        var zero = Virtualization.Window(10_000, RowHeight, 100 * RowHeight, 400, overscan: 0);
+
+        await Assert.That(negative).IsEqualTo(zero);
+    }
+
+    /// <summary>The point of the exercise: control count tracks the viewport, not the data.</summary>
+    [Test]
+    public async Task WindowSize_IsBoundedByViewportNotItemCount()
+    {
+        var small = Virtualization.Window(100, RowHeight, 0, 400);
+        var huge = Virtualization.Window(1_000_000, RowHeight, 0, 400);
+
+        await Assert.That(huge.Count).IsEqualTo(small.Count);
+        await Assert.That(huge.Count).IsLessThan(30);
+    }
+}

--- a/Picea.Abies.Native/EventData.cs
+++ b/Picea.Abies.Native/EventData.cs
@@ -26,3 +26,16 @@ public sealed record ValueChangedData(double NewValue, double OldValue);
 /// <summary>Payload for selection changes (ComboBox.SelectionChanged).</summary>
 /// <param name="SelectedIndex">The newly selected index, or -1 when nothing is selected.</param>
 public sealed record SelectionChangedData(int SelectedIndex);
+
+/// <summary>
+/// Payload for scroll position changes (ScrollViewer.ViewChanged).
+/// <para>
+/// This is what makes large lists workable: the model derives which slice of
+/// the data is on screen and the view emits only those rows, so the control
+/// count is bounded by the viewport rather than the data.
+/// </para>
+/// </summary>
+/// <param name="VerticalOffset">Distance scrolled from the top, in pixels.</param>
+/// <param name="ViewportHeight">Height of the visible region, in pixels.</param>
+/// <param name="ExtentHeight">Total scrollable height, in pixels.</param>
+public sealed record ScrollChangedData(double VerticalOffset, double ViewportHeight, double ExtentHeight);

--- a/Picea.Abies.Native/Events.cs
+++ b/Picea.Abies.Native/Events.cs
@@ -72,4 +72,11 @@ public static class Events
     /// <summary>ComboBox selection change.</summary>
     public static Handler OnSelectionChanged(Func<SelectionChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => On("SelectionChanged", factory, id);
+
+    /// <summary>
+    /// ScrollViewer position change. Pair with a model that slices its data to
+    /// the visible range — see the list windowing guidance on Elements.ScrollViewer.
+    /// </summary>
+    public static Handler OnScrollChanged(Func<ScrollChangedData?, Message> factory, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => On("ScrollChanged", factory, id);
 }

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -200,6 +200,14 @@ public static class Properties
     public static DOM.Attribute Source(string uri, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Source", uri, id);
 
+    /// <summary>
+    /// ScrollViewer vertical scroll position. Writing it scrolls the control;
+    /// identical writes are skipped so a scroll-driven model does not fight the
+    /// user. Pair with <c>Events.OnScrollChanged</c>.
+    /// </summary>
+    public static DOM.Attribute VerticalOffset(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("VerticalOffset", Num(value), id);
+
     /// <summary>ToggleSwitch state (pair with OnToggled).</summary>
     public static DOM.Attribute IsOn(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("IsOn", value ? "True" : "False", id);

--- a/Picea.Abies.Native/Virtualization.cs
+++ b/Picea.Abies.Native/Virtualization.cs
@@ -1,0 +1,89 @@
+// =============================================================================
+// List Windowing
+// =============================================================================
+// Rendering a row per item stops being viable somewhere in the low thousands:
+// every row becomes a real native control that has to be created, measured and
+// arranged. Windowing keeps the control count proportional to the viewport
+// instead of the data — the model tracks the scroll position, and the view
+// emits only the rows that are on screen.
+//
+// This is deliberately a pure function rather than a control. Working out which
+// slice is visible, and how much empty space to leave above and below so the
+// scrollbar still reflects the whole list, is the part that is easy to get
+// wrong; it is also the part that is worth testing without a UI framework.
+//
+// What this is not: container recycling. Rows are created and destroyed as they
+// scroll in and out rather than being reused, so scrolling does more work than
+// a WinUI ItemsRepeater would. It bounds the control count, which is the
+// difference between a 50,000-row list being impossible and being usable.
+// =============================================================================
+
+namespace Picea.Abies.Native;
+
+/// <summary>
+/// The slice of a list that should be rendered, plus the empty space that keeps
+/// the scrollbar proportional to the whole list.
+/// </summary>
+/// <param name="StartIndex">Index of the first item to render.</param>
+/// <param name="Count">How many items to render.</param>
+/// <param name="TopPadding">Height to leave above the first rendered row.</param>
+/// <param name="BottomPadding">Height to leave below the last rendered row.</param>
+public readonly record struct ListWindow(int StartIndex, int Count, double TopPadding, double BottomPadding)
+{
+    /// <summary>Index just past the last rendered item.</summary>
+    public int EndIndex => StartIndex + Count;
+
+    /// <summary>An empty window, for an empty list.</summary>
+    public static ListWindow Empty { get; } = new(0, 0, 0, 0);
+}
+
+/// <summary>Helpers for rendering long lists without a control per item.</summary>
+public static class Virtualization
+{
+    /// <summary>
+    /// Works out which rows are visible for a given scroll position.
+    /// </summary>
+    /// <param name="itemCount">Total number of items in the list.</param>
+    /// <param name="rowHeight">Height of a single row, in pixels. Must be positive.</param>
+    /// <param name="scrollOffset">Current vertical scroll offset, from OnScrollChanged.</param>
+    /// <param name="viewportHeight">Visible height, from OnScrollChanged.</param>
+    /// <param name="overscan">
+    /// Extra rows rendered above and below the viewport. Without a few, fast
+    /// scrolling shows blank space at the leading edge before the next render
+    /// lands; too many gives back the cost windowing is there to avoid.
+    /// </param>
+    /// <returns>The slice to render and the padding around it.</returns>
+    public static ListWindow Window(
+        int itemCount,
+        double rowHeight,
+        double scrollOffset,
+        double viewportHeight,
+        int overscan = 4)
+    {
+        if (itemCount <= 0 || rowHeight <= 0)
+        {
+            return ListWindow.Empty;
+        }
+
+        // A viewport height of zero means the control has not been measured yet
+        // — the very first render, before any scroll event has arrived. Render a
+        // screenful's worth of rows rather than nothing, so the list is not
+        // blank until the user touches it.
+        var effectiveViewport = viewportHeight > 0 ? viewportHeight : rowHeight * 20;
+
+        var clampedOffset = Math.Clamp(scrollOffset, 0, Math.Max(0, itemCount * rowHeight - effectiveViewport));
+
+        var firstVisible = (int)Math.Floor(clampedOffset / rowHeight);
+        var visibleCount = (int)Math.Ceiling(effectiveViewport / rowHeight) + 1;
+
+        var start = Math.Max(0, firstVisible - Math.Max(0, overscan));
+        var end = Math.Min(itemCount, firstVisible + visibleCount + Math.Max(0, overscan));
+        var count = Math.Max(0, end - start);
+
+        return new ListWindow(
+            StartIndex: start,
+            Count: count,
+            TopPadding: start * rowHeight,
+            BottomPadding: Math.Max(0, (itemCount - end) * rowHeight));
+    }
+}

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -330,6 +330,16 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
             case ScrollViewer sv:
                 switch (name)
                 {
+                    case "VerticalOffset":
+                        // Programmatic scroll. Guarded because ChangeView raises
+                        // ViewChanged, which would echo straight back as a message.
+                        if (value is not null)
+                        {
+                            var target = D(value);
+                            if (Math.Abs(sv.VerticalOffset - target) > 0.5)
+                                sv.ChangeView(null, target, null, true);
+                        }
+                        return;
                     case "Padding":
                         sv.Padding = value is null ? default : ParseThickness(value);
                         return;
@@ -548,6 +558,20 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                     checkBox.Checked -= handler;
                     checkBox.Unchecked -= handler;
                 };
+                return;
+            }
+            case (ScrollViewer scrollViewer, "ScrollChanged"):
+            {
+                EventHandler<ScrollViewerViewChangedEventArgs> handler = (s, _) =>
+                {
+                    if (sink.IsApplying)
+                        return;
+                    var view = (ScrollViewer)s!;
+                    sink.OnNativeEvent(elementId, "ScrollChanged",
+                        new ScrollChangedData(view.VerticalOffset, view.ViewportHeight, view.ExtentHeight));
+                };
+                scrollViewer.ViewChanged += handler;
+                _detachers[(control, eventName)] = () => scrollViewer.ViewChanged -= handler;
                 return;
             }
             case (ToggleSwitch toggle, "Toggled"):

--- a/docs/guides/native-apps.md
+++ b/docs/guides/native-apps.md
@@ -122,6 +122,71 @@ it should land after an arbitrary rewrite.
 `Slider.Value` and `ComboBox.SelectedIndex` guard identical writes for the same reason:
 re-setting them would re-raise their change events.
 
+## Long lists
+
+A row per item stops being viable somewhere in the low thousands: every row is a real
+native control that must be created, measured and arranged. The fix is to let the model
+track the scroll position and have the view emit only the rows on screen, so the control
+count is bounded by the viewport rather than the data.
+
+`Virtualization.Window` does the arithmetic — which slice is visible, and how much empty
+space to leave above and below so the scrollbar still reflects the whole list:
+
+```csharp
+public record Model(IReadOnlyList<Row> Rows, double ScrollOffset, double ViewportHeight);
+public record Scrolled(double Offset, double Viewport) : Message;
+
+// Transition
+Scrolled m => model with { ScrollOffset = m.Offset, ViewportHeight = m.Viewport },
+
+// View
+private const double RowHeight = 40;
+
+public static Document View(Model model)
+{
+    var window = Virtualization.Window(
+        itemCount: model.Rows.Count,
+        rowHeight: RowHeight,
+        scrollOffset: model.ScrollOffset,
+        viewportHeight: model.ViewportHeight);
+
+    return new("Big list",
+        ScrollViewer([OnScrollChanged(d => new Scrolled(d!.VerticalOffset, d.ViewportHeight))],
+            StackPanel([],
+            [
+                // Empty space standing in for the rows above the viewport.
+                Border([Id("pad-top"), Height(window.TopPadding)], TextBlock([Id("pad-top-x")], "")),
+
+                .. model.Rows
+                    .Skip(window.StartIndex)
+                    .Take(window.Count)
+                    .Select((row, i) =>
+                    {
+                        var index = window.StartIndex + i;
+                        return TextBlock([Id($"row-{index}"), Key(row.Id), Height(RowHeight)], row.Label);
+                    }),
+
+                Border([Id("pad-bottom"), Height(window.BottomPadding)], TextBlock([Id("pad-bottom-x")], "")),
+            ])));
+}
+```
+
+The two spacers are what keep the scrollbar honest — without them it would size itself to
+the handful of rendered rows. Keys still matter: rows entering and leaving the window are
+reconciled by key, so scrolling moves controls rather than rebuilding them.
+
+**What this is and isn't.** This is *windowing*: the control count is bounded by the
+viewport, which is the difference between a 50,000-row list being impossible and being
+usable. It is not *container recycling* — rows are created and destroyed as they scroll in
+and out rather than reused, so scrolling does more work than a WinUI `ItemsRepeater`
+would. Recycling needs the patch interpreter to keep a shadow of unrealized rows so
+patches aimed at off-screen items are not lost, which is a larger change; see the
+[production-readiness plan](../investigations/winui-native-production-readiness.md).
+
+`Properties.VerticalOffset` scrolls the control programmatically, for cases like jumping
+to a search result. It skips identical writes so a scroll-driven model does not fight the
+user mid-gesture.
+
 ## Handling failures
 
 Rendering and dispatch failures are reported rather than silent. Pass `renderFaulted` to
@@ -159,7 +224,8 @@ sees the desktop head alone. Both are built and render-smoke-tested in CI.
 
 ## Known limitations
 
-- No virtualized list recycling yet — large lists build one control per item.
+- Long lists are handled by windowing (`Virtualization.Window`), not container recycling —
+  rows are created and destroyed as they scroll rather than reused.
 - Styling is direct property assignment; there is no theme-resource mapping yet.
 - No accessibility/automation-peer pass.
 - `Document.Head` is a no-op; `Document.Title` maps to the window title.

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -286,9 +286,20 @@ same branch, so keyed reordering works for items as it does for panels.
 **Still open, deliberately.** Each of the remaining items is genuinely multi-week, and two
 of them should not be rushed:
 
-- **Virtualized list recycling.** Large lists currently build one control per item.
-  Reactor's element pooling is the benchmark to beat, and matching it is a project, not a
-  patch.
+- **Virtualized lists — windowing done, recycling open.** `Virtualization.Window` bounds
+  the control count by the viewport rather than the data: the model tracks the scroll
+  offset, the view emits only visible rows plus spacers that keep the scrollbar
+  proportional. That is the difference between a 50,000-row list being impossible and
+  being usable, and it needed no change to `INativeBackend` — which matters now that the
+  interface is published.
+
+  Container *recycling* (a WinUI `ItemsRepeater` reusing row controls) is still open, and
+  it is the part that is a project rather than a patch. The obstacle is not the control:
+  it is that the diff produces patches for the whole list while only some rows exist, so
+  a patch aimed at an off-screen row would be dropped and the row would be stale when it
+  scrolled back in. Doing it correctly means the interpreter keeping a shadow of
+  unrealized rows and replaying it on realization — a real design change to the core, and
+  one that deserves its own ADR. Reactor's element pooling remains the benchmark.
 - **Styling/theming.** This would *add public API*, immediately after Phase 2 froze it.
   Designing a theming surface under time pressure is the fastest way to acquire the kind
   of API debt Phase 2 just paid off. It deserves its own ADR: mapping onto XAML theme


### PR DESCRIPTION
### What

- `ScrollChangedData` + `Events.OnScrollChanged`, wired to `ScrollViewer.ViewChanged`
- `Properties.VerticalOffset` for programmatic scrolling
- **`Virtualization.Window`** — a pure function returning the visible slice plus the padding above and below it

### Why

A row per item stops being viable somewhere in the low thousands: every row is a real native control that must be created, measured and arranged. Windowing lets the model track the scroll position and the view emit only on-screen rows, so **control count is bounded by the viewport rather than the data**.

The window arithmetic is the part that's easy to get wrong and worth testing without a UI framework, so it's a pure function rather than a control.

The padding isn't incidental — without it the scrollbar sizes itself to the handful of rendered rows instead of the list. A test asserts `TopPadding + rows + BottomPadding` always spans the full list height, across several scroll offsets.

### Scope — windowing, not recycling

I want to be precise, because "virtualization" covers two things:

| | |
| --- | --- |
| ✅ **Windowing** | Control count bounded by viewport. The difference between a 50,000-row list being impossible and being usable. |
| ❌ **Container recycling** | Rows are created and destroyed as they scroll, not reused. Scrolling does more work than a WinUI `ItemsRepeater` would. |

**Why recycling isn't here.** The obstacle isn't the control — it's that the diff emits patches for the *whole* list while only some rows exist. A patch aimed at an off-screen row would be dropped, and that row would be stale when it scrolled back in. Doing it correctly means the interpreter keeping a shadow of unrealized rows and replaying it on realization: a real design change to the core, deserving its own ADR rather than being smuggled into a feature PR.

That's recorded in the guide and the plan, so the limitation is visible to users rather than discovered.

**Nothing here touches `INativeBackend`** — which matters now that it's published at 2.3.x and adding members would be breaking.

### Testing

**49 native tests pass** (12 new), all pure and headless. The boundaries are where off-by-one errors turn into blank rows, so they're covered explicitly:

- padding + rows + padding spans the full list height, at 5 offsets
- clamping when scrolled past the end
- viewport taller than the list renders everything, no padding
- **unmeasured viewport on first render returns a screenful, not nothing** — otherwise the list is blank until the user touches it
- non-positive row height (divide-by-zero guard), negative overscan
- window size tracks the viewport, not the item count — 100 items and 1,000,000 items produce the same window

Full solution build 0 errors; `dotnet format` clean on all three projects; `DocSnippetCheck` 31 compiled / 0 failed.

### Not covered

No on-screen CI verification of scrolling — the render and interaction checks cover first render and click/subscription round-trips, but nothing drives a scroll gesture. The arithmetic is pinned headlessly; the wiring is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)