### PR TITLE
feat(native): Add theming and accessibility; close out list recycling

### DIFF
--- a/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
+++ b/Picea.Abies.Native.Tests/PatchInterpreterTests.cs
@@ -156,8 +156,10 @@ public class PatchInterpreterTests
         var (interpreter, _) = Create();
         interpreter.Apply(Operations.Diff(null, ClickableButton()));
 
-        Exception? reported = null;
-        interpreter.Faulted = ex => reported = ex;
+        // Signalled rather than slept on: the fault arrives on another thread,
+        // and a fixed delay is a race that a loaded CI runner loses.
+        var reported = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        interpreter.Faulted = ex => reported.TrySetResult(ex);
         interpreter.Dispatch = async _ =>
         {
             await Task.Yield();
@@ -165,10 +167,10 @@ public class PatchInterpreterTests
         };
 
         interpreter.OnNativeEvent("b1", "Click", null);
-        await Task.Delay(50);
+        var fault = await reported.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
-        await Assert.That(reported!.Message).IsEqualTo("update blew up");
+        await Assert.That(fault).IsTypeOf<InvalidOperationException>();
+        await Assert.That(fault.Message).IsEqualTo("update blew up");
     }
 
     [Test]
@@ -194,10 +196,18 @@ public class PatchInterpreterTests
 
         Exception? reported = null;
         interpreter.Faulted = ex => reported = ex;
-        interpreter.Dispatch = _ => ValueTask.CompletedTask;
+
+        // Wait on the dispatch itself rather than on the clock, so the assertion
+        // runs after the work it is about.
+        var dispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        interpreter.Dispatch = _ =>
+        {
+            dispatched.TrySetResult();
+            return ValueTask.CompletedTask;
+        };
 
         interpreter.OnNativeEvent("b1", "Click", null);
-        await Task.Delay(50);
+        await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
         await Assert.That(reported).IsNull();
     }
@@ -212,11 +222,16 @@ public class PatchInterpreterTests
         var (interpreter, _) = Create();
         interpreter.Apply(Operations.Diff(null, ClickableButton()));
 
-        interpreter.Faulted = _ => throw new InvalidOperationException("handler is broken too");
+        var handlerRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        interpreter.Faulted = _ =>
+        {
+            handlerRan.TrySetResult();
+            throw new InvalidOperationException("handler is broken too");
+        };
         interpreter.Dispatch = _ => throw new InvalidOperationException("dispatch failed");
 
         interpreter.OnNativeEvent("b1", "Click", null);
-        await Task.Delay(50);
+        await handlerRan.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
         // Reaching here without an unhandled exception is the assertion.
         await Assert.That(interpreter.ControlCount).IsEqualTo(1);

--- a/Picea.Abies.Native.Tests/ThemeAndAccessibilityTests.cs
+++ b/Picea.Abies.Native.Tests/ThemeAndAccessibilityTests.cs
@@ -1,0 +1,128 @@
+// =============================================================================
+// Theme and Accessibility Tests
+// =============================================================================
+// Both are encoded as ordinary string attributes, so the vocabulary side is
+// testable headlessly; resolving a theme key against a live resource dictionary
+// is the backend's job and needs a running app.
+// =============================================================================
+
+using Picea.Abies.DOM;
+using Picea.Abies.Native.Rendering;
+using static Picea.Abies.Native.Elements;
+using static Picea.Abies.Native.Properties;
+
+namespace Picea.Abies.Native.Tests;
+
+public class ThemeAndAccessibilityTests
+{
+    private static (PatchInterpreter<FakeControl> Interpreter, FakeBackend Backend) Create()
+    {
+        var backend = new FakeBackend();
+        return (new PatchInterpreter<FakeControl>(backend), backend);
+    }
+
+    // =========================================================================
+    // Theme
+    // =========================================================================
+
+    [Test]
+    public async Task ThemeColor_EncodesAsAResourceLookup()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)StackPanel([Id("p"), Background(ThemeColor.SurfaceCard)],
+            [TextBlock([Id("t"), Foreground(ThemeColor.TextSecondary)], "hi")]);
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        await Assert.That(backend.Root!.Props["Background"]).IsEqualTo("theme:CardBackgroundFillColorDefaultBrush");
+        await Assert.That(backend.Root!.Children[0].Props["Foreground"]).IsEqualTo("theme:TextFillColorSecondaryBrush");
+    }
+
+    /// <summary>Literal colours must stay literal — the two forms have to be distinguishable.</summary>
+    [Test]
+    public async Task LiteralColour_IsNotTreatedAsATheme()
+    {
+        var (interpreter, backend) = Create();
+        interpreter.Apply(Operations.Diff(null, (Element)StackPanel([Id("p"), Background("#102030")], [])));
+
+        await Assert.That(backend.Root!.Props["Background"]).IsEqualTo("#102030");
+        await Assert.That(Theme.TryDecode("#102030")).IsNull();
+    }
+
+    [Test]
+    public async Task TryDecode_RoundTripsEveryRole()
+    {
+        foreach (var role in Enum.GetValues<ThemeColor>())
+        {
+            var encoded = Theme.Encode(role);
+            await Assert.That(Theme.TryDecode(encoded)).IsEqualTo(Theme.ResourceKey(role));
+        }
+    }
+
+    [Test]
+    public async Task EveryRole_MapsToAResourceKey()
+    {
+        foreach (var role in Enum.GetValues<ThemeColor>())
+        {
+            await Assert.That(string.IsNullOrWhiteSpace(Theme.ResourceKey(role))).IsFalse();
+        }
+    }
+
+    /// <summary>Switching a literal colour to a theme role is an ordinary attribute update.</summary>
+    [Test]
+    public async Task SwitchingFromLiteralToTheme_UpdatesInPlace()
+    {
+        var (interpreter, backend) = Create();
+        var before = (Element)StackPanel([Id("p"), Background("#000000")], []);
+        var after = (Element)StackPanel([Id("p"), Background(ThemeColor.SurfaceBase)], []);
+
+        interpreter.Apply(Operations.Diff(null, before));
+        var created = backend.AllCreated.Count;
+        interpreter.Apply(Operations.Diff(before, after));
+
+        await Assert.That(backend.Root!.Props["Background"]).IsEqualTo("theme:SolidBackgroundFillColorBaseBrush");
+        await Assert.That(backend.AllCreated.Count).IsEqualTo(created);
+    }
+
+    // =========================================================================
+    // Accessibility
+    // =========================================================================
+
+    [Test]
+    public async Task AutomationName_ReachesTheControl()
+    {
+        var (interpreter, backend) = Create();
+        var view = (Element)StackPanel([Id("p")],
+            [Button([Id("b"), AutomationName("Delete item"), AutomationHelpText("Removes the row")], "🗑")]);
+
+        interpreter.Apply(Operations.Diff(null, view));
+
+        var button = backend.Root!.Children[0];
+        await Assert.That(button.Props["AutomationName"]).IsEqualTo("Delete item");
+        await Assert.That(button.Props["AutomationHelpText"]).IsEqualTo("Removes the row");
+    }
+
+    [Test]
+    public async Task AccessibilityHidden_IsCarried()
+    {
+        var (interpreter, backend) = Create();
+        interpreter.Apply(Operations.Diff(null,
+            (Element)StackPanel([Id("p"), AccessibilityHidden(true)], [])));
+
+        await Assert.That(backend.Root!.Props["AccessibilityHidden"]).IsEqualTo("True");
+    }
+
+    /// <summary>Removing the attribute must reset it, not leave a stale name announced.</summary>
+    [Test]
+    public async Task RemovingAutomationName_ResetsIt()
+    {
+        var (interpreter, backend) = Create();
+        var before = (Element)StackPanel([Id("p")], [Button([Id("b"), AutomationName("Old")], "x")]);
+        var after = (Element)StackPanel([Id("p")], [Button([Id("b")], "x")]);
+
+        interpreter.Apply(Operations.Diff(null, before));
+        interpreter.Apply(Operations.Diff(before, after));
+
+        await Assert.That(backend.AllCreated.Single(c => c.Id == "b").Props.ContainsKey("AutomationName")).IsFalse();
+    }
+}

--- a/Picea.Abies.Native.Tests/VirtualizationTests.cs
+++ b/Picea.Abies.Native.Tests/VirtualizationTests.cs
@@ -6,6 +6,9 @@
 // including the boundaries where off-by-one errors show up as blank rows.
 // =============================================================================
 
+using Picea.Abies.DOM;
+using Picea.Abies.Native.Rendering;
+
 namespace Picea.Abies.Native.Tests;
 
 public class VirtualizationTests
@@ -127,6 +130,38 @@ public class VirtualizationTests
         var zero = Virtualization.Window(10_000, RowHeight, 100 * RowHeight, 400, overscan: 0);
 
         await Assert.That(negative).IsEqualTo(zero);
+    }
+
+    /// <summary>
+    /// Scrolling by one row should recycle the overlap: only the row entering
+    /// the window is created. If this regresses, windowing degrades into
+    /// rebuilding the whole visible list on every scroll event.
+    /// </summary>
+    [Test]
+    public async Task ScrollingOneRow_OnlyCreatesTheEnteringRow()
+    {
+        var backend = new FakeBackend();
+        var interpreter = new PatchInterpreter<FakeControl>(backend);
+
+        static Element Rows(ListWindow w) =>
+            (Element)Elements.StackPanel([Properties.Id("list")],
+            [
+                .. Enumerable.Range(w.StartIndex, w.Count).Select(i =>
+                    Elements.TextBlock([Properties.Id($"row-{i}"), Properties.Key($"k{i}")], $"item {i}")),
+            ]);
+
+        var before = Rows(Virtualization.Window(10_000, RowHeight, 0, 400, overscan: 0));
+        var after = Rows(Virtualization.Window(10_000, RowHeight, RowHeight, 400, overscan: 0));
+
+        interpreter.Apply(Operations.Diff(null, before));
+        var createdAfterFirstRender = backend.AllCreated.Count;
+
+        interpreter.Apply(Operations.Diff(before, after));
+        var createdByScrolling = backend.AllCreated.Count - createdAfterFirstRender;
+
+        // One row leaves the top, one enters the bottom; everything between is reused.
+        await Assert.That(createdByScrolling).IsEqualTo(1)
+            .Because("scrolling one row should build one row, not rebuild the window");
     }
 
     /// <summary>The point of the exercise: control count tracks the viewport, not the data.</summary>

--- a/Picea.Abies.Native/Properties.cs
+++ b/Picea.Abies.Native/Properties.cs
@@ -138,9 +138,20 @@ public static class Properties
     public static DOM.Attribute Foreground(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Foreground", color, id);
 
+    /// <summary>
+    /// Foreground from the platform theme, so it follows light and dark.
+    /// Prefer this over a literal colour, which is necessarily wrong in one theme.
+    /// </summary>
+    public static DOM.Attribute Foreground(ThemeColor color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Foreground", Theme.Encode(color), id);
+
     /// <summary>Background color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>
     public static DOM.Attribute Background(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Background", color, id);
+
+    /// <summary>Background from the platform theme, so it follows light and dark.</summary>
+    public static DOM.Attribute Background(ThemeColor color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("Background", Theme.Encode(color), id);
 
     public static DOM.Attribute CornerRadius(double uniform, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("CornerRadius", Num(uniform), id);
@@ -151,6 +162,10 @@ public static class Properties
     /// <summary>Border brush color: "#RRGGBB", "#AARRGGBB", or a named color.</summary>
     public static DOM.Attribute BorderBrush(string color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("BorderBrush", color, id);
+
+    /// <summary>Border brush from the platform theme, so it follows light and dark.</summary>
+    public static DOM.Attribute BorderBrush(ThemeColor color, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("BorderBrush", Theme.Encode(color), id);
 
     public static DOM.Attribute Opacity(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("Opacity", Num(value), id);
@@ -207,6 +222,34 @@ public static class Properties
     /// </summary>
     public static DOM.Attribute VerticalOffset(double value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
         => Attr("VerticalOffset", Num(value), id);
+
+    // =========================================================================
+    // Accessibility
+    // =========================================================================
+    // Controls with visible text — Button, CheckBox, TextBlock — already expose
+    // that text to assistive technology. These are for the ones that do not: an
+    // icon-only button, a TextBox with no adjacent label, a Slider.
+
+    /// <summary>
+    /// The name assistive technology announces for this control. Required for
+    /// controls with no visible text of their own.
+    /// </summary>
+    public static DOM.Attribute AutomationName(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("AutomationName", value, id);
+
+    /// <summary>
+    /// Supplementary description announced after the name — the equivalent of a
+    /// tooltip for assistive technology. Use for hints, not for the name itself.
+    /// </summary>
+    public static DOM.Attribute AutomationHelpText(string value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("AutomationHelpText", value, id);
+
+    /// <summary>
+    /// Hides a control from assistive technology. For decoration only — never
+    /// for something the user must be able to reach.
+    /// </summary>
+    public static DOM.Attribute AccessibilityHidden(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)
+        => Attr("AccessibilityHidden", value ? "True" : "False", id);
 
     /// <summary>ToggleSwitch state (pair with OnToggled).</summary>
     public static DOM.Attribute IsOn(bool value, [UniqueId(UniqueIdFormat.HtmlId)] string? id = null)

--- a/Picea.Abies.Native/Theme.cs
+++ b/Picea.Abies.Native/Theme.cs
@@ -1,0 +1,94 @@
+// =============================================================================
+// Theme Brushes
+// =============================================================================
+// A literal colour like "#1F1F1F" is wrong in one of the two themes. WinUI
+// already ships a full set of semantic brushes that follow light/dark, so this
+// maps onto those rather than reinventing a token system: the theme story is
+// "use the platform's", which is also what ADR-027 said it wanted.
+//
+// Values are carried as "theme:<ResourceKey>" so the backend can tell them from
+// literal colours. A key that does not resolve on some platform leaves the
+// property unset and reports through the renderer's fault callback, rather than
+// throwing — a missing brush should not take down a window.
+// =============================================================================
+
+namespace Picea.Abies.Native;
+
+/// <summary>
+/// Semantic colour roles, mapped to the platform's theme brushes so they follow
+/// light and dark automatically.
+/// </summary>
+public enum ThemeColor
+{
+    /// <summary>Primary body and heading text.</summary>
+    TextPrimary,
+
+    /// <summary>De-emphasised text: captions, secondary detail.</summary>
+    TextSecondary,
+
+    /// <summary>Text belonging to a disabled control.</summary>
+    TextDisabled,
+
+    /// <summary>The accent colour, for emphasis and selected state.</summary>
+    Accent,
+
+    /// <summary>The window's base background.</summary>
+    SurfaceBase,
+
+    /// <summary>A raised surface — cards, list rows, panels above the base.</summary>
+    SurfaceCard,
+
+    /// <summary>Default control and divider strokes.</summary>
+    Stroke,
+
+    /// <summary>Success state.</summary>
+    Success,
+
+    /// <summary>Caution state.</summary>
+    Caution,
+
+    /// <summary>Error or destructive state.</summary>
+    Critical,
+}
+
+/// <summary>Maps semantic roles onto platform theme resource keys.</summary>
+public static class Theme
+{
+    /// <summary>Prefix marking an attribute value as a theme lookup rather than a literal colour.</summary>
+    public const string Prefix = "theme:";
+
+    private static readonly Dictionary<ThemeColor, string> _resourceKeys = new()
+    {
+        [ThemeColor.TextPrimary] = "TextFillColorPrimaryBrush",
+        [ThemeColor.TextSecondary] = "TextFillColorSecondaryBrush",
+        [ThemeColor.TextDisabled] = "TextFillColorDisabledBrush",
+        [ThemeColor.Accent] = "AccentFillColorDefaultBrush",
+        [ThemeColor.SurfaceBase] = "SolidBackgroundFillColorBaseBrush",
+        [ThemeColor.SurfaceCard] = "CardBackgroundFillColorDefaultBrush",
+        [ThemeColor.Stroke] = "ControlStrokeColorDefaultBrush",
+        [ThemeColor.Success] = "SystemFillColorSuccessBrush",
+        [ThemeColor.Caution] = "SystemFillColorCautionBrush",
+        [ThemeColor.Critical] = "SystemFillColorCriticalBrush",
+    };
+
+    /// <summary>The platform resource key backing a semantic role.</summary>
+    public static string ResourceKey(ThemeColor color) =>
+        _resourceKeys.TryGetValue(color, out var key)
+            ? key
+            : throw new ArgumentOutOfRangeException(nameof(color), color, "No theme resource mapped for this colour.");
+
+    /// <summary>Encodes a semantic role as an attribute value.</summary>
+    public static string Encode(ThemeColor color) => Prefix + ResourceKey(color);
+
+    /// <summary>Encodes an explicit platform resource key, for brushes the enum does not name.</summary>
+    public static string Encode(string resourceKey) => Prefix + resourceKey;
+
+    /// <summary>
+    /// Returns the resource key if <paramref name="value"/> is a theme lookup,
+    /// or null if it is a literal colour.
+    /// </summary>
+    public static string? TryDecode(string? value) =>
+        value is not null && value.StartsWith(Prefix, StringComparison.Ordinal)
+            ? value[Prefix.Length..]
+            : null;
+}

--- a/Picea.Abies.WinUI/Runtime.cs
+++ b/Picea.Abies.WinUI/Runtime.cs
@@ -45,11 +45,12 @@ public static class Runtime
         where TProgram : Program<TModel, TArgument>
     {
         var dispatcherQueue = rootHost.DispatcherQueue;
-        var backend = new WinUIBackend(rootHost);
-        var patchInterpreter = new PatchInterpreter<FrameworkElement>(backend);
 
         void Report(Exception exception) =>
             (renderFaulted ?? DefaultRenderFaulted).Invoke(exception);
+
+        var backend = new WinUIBackend(rootHost, brushFaulted: Report);
+        var patchInterpreter = new PatchInterpreter<FrameworkElement>(backend);
 
         Runtime<TProgram, TModel, TArgument>? runtime = null;
         patchInterpreter.Dispatch = async message =>

--- a/Picea.Abies.WinUI/WinUIBackend.cs
+++ b/Picea.Abies.WinUI/WinUIBackend.cs
@@ -11,6 +11,7 @@
 // =============================================================================
 
 using System.Globalization;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Picea.Abies.Native;
@@ -25,10 +26,17 @@ namespace Picea.Abies.WinUI;
 public sealed class WinUIBackend : INativeBackend<FrameworkElement>
 {
     private readonly Panel _rootHost;
+    private readonly Action<Exception>? _brushFaulted;
     private readonly Dictionary<(FrameworkElement Control, string EventName), Action> _detachers = [];
 
     /// <param name="rootHost">The panel that receives the root control (e.g., the window's content grid).</param>
-    public WinUIBackend(Panel rootHost) => _rootHost = rootHost;
+    /// <param name="brushFaulted">
+    /// Receives styling failures that are recoverable — currently a theme brush
+    /// key the platform does not define. Optional; when null such failures are
+    /// silent and the property keeps its default.
+    /// </param>
+    public WinUIBackend(Panel rootHost, Action<Exception>? brushFaulted = null)
+        => (_rootHost, _brushFaulted) = (rootHost, brushFaulted);
 
     // =========================================================================
     // Control factory
@@ -126,6 +134,25 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
                     cFs.ClearValue(Control.FontSizeProperty);
                 else
                     cFs.FontSize = D(value);
+                return;
+            case "AutomationName":
+                if (value is null)
+                    control.ClearValue(AutomationProperties.NameProperty);
+                else
+                    AutomationProperties.SetName(control, value);
+                return;
+            case "AutomationHelpText":
+                if (value is null)
+                    control.ClearValue(AutomationProperties.HelpTextProperty);
+                else
+                    AutomationProperties.SetHelpText(control, value);
+                return;
+            case "AccessibilityHidden":
+                AutomationProperties.SetAccessibilityView(
+                    control,
+                    value is not null && bool.Parse(value)
+                        ? Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw
+                        : Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Content);
                 return;
             case "Grid.Row":
                 Grid.SetRow(control, I(value ?? "0"));
@@ -655,12 +682,37 @@ public sealed class WinUIBackend : INativeBackend<FrameworkElement>
     /// Sets a brush property, or clears it back to its theme default when
     /// <paramref name="value"/> is null (i.e. the attribute was removed).
     /// </summary>
-    private static void SetBrush(DependencyObject target, DependencyProperty property, string? value)
+    private void SetBrush(DependencyObject target, DependencyProperty property, string? value)
     {
         if (value is null)
+        {
             target.ClearValue(property);
-        else
-            target.SetValue(property, new SolidColorBrush(ParseColor(value)));
+            return;
+        }
+
+        if (Theme.TryDecode(value) is { } resourceKey)
+        {
+            // A theme key that does not resolve on this platform leaves the
+            // property at its default and reports, rather than throwing. A
+            // missing brush is a styling problem, not a reason to lose a window.
+            if (Application.Current?.Resources is { } resources &&
+                resources.TryGetValue(resourceKey, out var resource) &&
+                resource is Brush themeBrush)
+            {
+                target.SetValue(property, themeBrush);
+            }
+            else
+            {
+                target.ClearValue(property);
+                _brushFaulted?.Invoke(new KeyNotFoundException(
+                    $"Theme brush '{resourceKey}' is not defined by the current platform theme; " +
+                    "the property was left at its default."));
+            }
+
+            return;
+        }
+
+        target.SetValue(property, new SolidColorBrush(ParseColor(value)));
     }
 
     private static Color ParseColor(string value)

--- a/docs/adr/ADR-029-native-theming-via-platform-brushes.md
+++ b/docs/adr/ADR-029-native-theming-via-platform-brushes.md
@@ -1,0 +1,89 @@
+# ADR-029: Native Theming via Platform Brushes
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Decision Makers:** Maurice Peters
+
+## Context
+
+The native vocabulary took colours as literal strings — `Foreground("#1F1F1F")`,
+`Background("gray")`. That is unusable in practice for one reason: **a literal colour is
+wrong in one of the two themes.** An app styled for light mode is unreadable in dark mode
+and vice versa, and there was no way to express "the normal text colour".
+
+[ADR-027](./ADR-027-native-winui-renderer.md) anticipated this, listing as roadmap work a
+"styling/theming story (map to XAML theme resources rather than reinventing)". This records
+the decision it deferred.
+
+The constraint that shapes it: `Picea.Abies.Native` is now published (2.3.x), so
+`INativeBackend<T>` cannot gain members without a breaking change.
+
+## Decision
+
+**Map semantic roles onto the platform's own theme brushes. Do not build a token system.**
+
+1. A `ThemeColor` enum names roles, not colours: `TextPrimary`, `TextSecondary`,
+   `TextDisabled`, `Accent`, `SurfaceBase`, `SurfaceCard`, `Stroke`, `Success`, `Caution`,
+   `Critical`.
+2. `Theme` maps each role to a WinUI theme resource key
+   (`TextFillColorPrimaryBrush`, `CardBackgroundFillColorDefaultBrush`, …).
+3. `Properties.Foreground`/`Background`/`BorderBrush` gain `ThemeColor` overloads. The
+   existing `string` overloads stay, for cases where a specific colour is genuinely wanted.
+4. The value is carried as `"theme:<ResourceKey>"`, so the backend can tell a lookup from a
+   literal without a new attribute or interface member.
+5. The backend resolves it against `Application.Current.Resources`. **A key that does not
+   resolve leaves the property at its default and reports through the renderer's fault
+   callback** rather than throwing.
+
+## Consequences
+
+### Positive
+
+- Light and dark work with no per-app effort, and match the rest of the OS — including
+  high-contrast themes, which a hand-rolled palette would miss.
+- Purely additive. No change to `INativeBackend<T>`, no change to existing views, and
+  literal colours keep working.
+- The encoding needs no new plumbing: it is an ordinary string attribute, so the diff,
+  the interpreter and the headless tests treat it like any other.
+
+### Negative
+
+- The role list is small and opinionated. Apps wanting a brush outside it can pass an
+  explicit key via `Theme.Encode(string)`, which is less discoverable than the enum.
+- The resource keys are WinUI's. A future Avalonia or AppKit backend would need its own
+  mapping for the same roles — which is the correct shape, but it is work.
+- Roles are resolved per property write, so a runtime theme switch only takes effect for
+  properties the diff rewrites. Full live re-theming would need the renderer to re-resolve
+  brushes on a theme-change event; not done, and not currently needed.
+
+### Neutral
+
+- The mapped keys are not verified at build time. That is why a missing key degrades to a
+  reported fault instead of an exception: the failure mode is a control with default
+  styling and a logged message, not a lost window.
+
+## Alternatives Considered
+
+### Alternative 1: A framework-level token system
+
+Define Abies's own tokens and resolve them to colours per theme. Rejected: it duplicates
+what the platform already ships, drifts from the OS as WinUI evolves, and would not follow
+high-contrast or user accent-colour settings without reimplementing all of it.
+
+### Alternative 2: Typed brush objects in the vocabulary
+
+Model brushes as first-class vocabulary values rather than encoded strings. Rejected: the
+vocabulary is deliberately string-valued so the diff can compare attributes cheaply and the
+interpreter stays platform-neutral. Introducing a typed brush would push platform types
+into `Picea.Abies.Native`, which has no UI dependency by design.
+
+### Alternative 3: Wait for a full design
+
+Leave theming out until a complete story exists. Rejected: literal colours are actively
+harmful — they ship apps that are unreadable in half the world's configurations — and this
+mapping is small, additive and reversible.
+
+## Related Decisions
+
+- [ADR-027: Native WinUI Renderer](./ADR-027-native-winui-renderer.md)
+- [ADR-028: Program Core/View Split](./ADR-028-program-core-view-split.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ ADRs document significant architectural decisions, their context, and consequenc
 | [ADR-026](./ADR-026-debugger-auto-mount-with-csharp-api.md) | Debugger Auto-Mount with C# API | Accepted | Adds automatic debugger mount behavior with the C# API |
 | [ADR-027](./ADR-027-native-winui-renderer.md) | Native WinUI Renderer via Patch-Stream Interpretation | Accepted | Native controls as a third `Apply` implementation; zero core changes |
 | [ADR-028](./ADR-028-program-core-view-split.md) | Program Core/View Split | Accepted | `ProgramCore` + `ProgramView` + `WithView`; share a core across renderers |
+| [ADR-029](./ADR-029-native-theming-via-platform-brushes.md) | Native Theming via Platform Brushes | Accepted | Semantic roles mapped to WinUI theme brushes; light/dark for free |
 
 > **Note:** There are two files numbered ADR-005: [ADR-005-webassembly-runtime.md](./ADR-005-webassembly-runtime.md) (indexed above) and [ADR-005-security-scanning-sast-dast-sca.md](./ADR-005-security-scanning-sast-dast-sca.md) (security scanning). The security scanning ADR was created separately and retains its number for historical reasons.
 

--- a/docs/guides/native-apps.md
+++ b/docs/guides/native-apps.md
@@ -175,17 +175,59 @@ The two spacers are what keep the scrollbar honest — without them it would siz
 the handful of rendered rows. Keys still matter: rows entering and leaving the window are
 reconciled by key, so scrolling moves controls rather than rebuilding them.
 
-**What this is and isn't.** This is *windowing*: the control count is bounded by the
-viewport, which is the difference between a 50,000-row list being impossible and being
-usable. It is not *container recycling* — rows are created and destroyed as they scroll in
-and out rather than reused, so scrolling does more work than a WinUI `ItemsRepeater`
-would. Recycling needs the patch interpreter to keep a shadow of unrealized rows so
-patches aimed at off-screen items are not lost, which is a larger change; see the
-[production-readiness plan](../investigations/winui-native-production-readiness.md).
+**Keys do most of what recycling would.** Because rows are keyed, scrolling reuses the
+overlap: scroll by one row and the diff creates exactly one control and destroys one,
+moving the other nineteen. Churn is proportional to rows *scrolled*, not to window size —
+there is a test asserting precisely that. A WinUI `ItemsRepeater` would go one step
+further and reuse the container itself, saving that single construction, but the large win
+— thousands of controls down to a viewport's worth — is already here.
 
 `Properties.VerticalOffset` scrolls the control programmatically, for cases like jumping
 to a search result. It skips identical writes so a scroll-driven model does not fight the
 user mid-gesture.
+
+## Theming
+
+A literal colour is wrong in one of the two themes. WinUI already ships semantic brushes
+that follow light and dark, so the theme story is "use the platform's":
+
+```csharp
+TextBlock([Foreground(ThemeColor.TextSecondary)], "Last updated 3m ago")
+Border([Background(ThemeColor.SurfaceCard), BorderBrush(ThemeColor.Stroke)], content)
+Button([Background(ThemeColor.Critical), OnClick(new Delete())], "Delete")
+```
+
+Roles: `TextPrimary`, `TextSecondary`, `TextDisabled`, `Accent`, `SurfaceBase`,
+`SurfaceCard`, `Stroke`, `Success`, `Caution`, `Critical`. The string overloads still take
+literal colours where you genuinely want one.
+
+A theme key the platform does not define leaves the property at its default and reports
+through `renderFaulted` rather than throwing — a missing brush is a styling problem, not a
+reason to lose a window.
+
+## Accessibility
+
+Controls with visible text — `Button`, `CheckBox`, `TextBlock` — already expose it to
+assistive technology. The ones that need help are those without: an icon-only button, a
+`TextBox` with no adjacent label, a `Slider`.
+
+```csharp
+Button([AutomationName("Delete item"), AutomationHelpText("Removes this row"),
+        OnClick(new Delete(id))], "🗑")
+
+TextBox([AutomationName("Search"), PlaceholderText("Search…"),
+         OnTextChanged(d => new QueryChanged(d!.Text))])
+```
+
+`AccessibilityHidden(true)` removes a control from the accessibility tree — for decoration
+only, never for something the user must reach.
+
+Automation peers work: the TaskTimer sample's CI interaction check drives buttons through
+`IInvokeProvider`, which is the same tree a screen reader reads.
+
+> **Not yet done:** there has been no audit against a real screen reader. These properties
+> make correct names *possible*; they do not prove any particular view is usable. Treat
+> that as open work.
 
 ## Handling failures
 
@@ -226,6 +268,6 @@ sees the desktop head alone. Both are built and render-smoke-tested in CI.
 
 - Long lists are handled by windowing (`Virtualization.Window`), not container recycling —
   rows are created and destroyed as they scroll rather than reused.
-- Styling is direct property assignment; there is no theme-resource mapping yet.
-- No accessibility/automation-peer pass.
+- Accessibility: automation names are supported, but no audit against a real screen
+  reader has been done.
 - `Document.Head` is a no-op; `Document.Title` maps to the window title.

--- a/docs/investigations/winui-native-production-readiness.md
+++ b/docs/investigations/winui-native-production-readiness.md
@@ -293,20 +293,33 @@ of them should not be rushed:
   being usable, and it needed no change to `INativeBackend` — which matters now that the
   interface is published.
 
-  Container *recycling* (a WinUI `ItemsRepeater` reusing row controls) is still open, and
-  it is the part that is a project rather than a patch. The obstacle is not the control:
-  it is that the diff produces patches for the whole list while only some rows exist, so
-  a patch aimed at an off-screen row would be dropped and the row would be stale when it
-  scrolled back in. Doing it correctly means the interpreter keeping a shadow of
-  unrealized rows and replaying it on realization — a real design change to the core, and
-  one that deserves its own ADR. Reactor's element pooling remains the benchmark.
-- **Styling/theming.** This would *add public API*, immediately after Phase 2 froze it.
-  Designing a theming surface under time pressure is the fastest way to acquire the kind
-  of API debt Phase 2 just paid off. It deserves its own ADR: mapping onto XAML theme
-  resources versus a framework-level abstraction is a real decision, not an
-  implementation detail.
-- **Accessibility / automation-peer pass.** Needs a real audit against screen readers,
-  not a plausible-looking API.
+  Container *recycling* turned out to be a much smaller prize than this plan assumed, and
+  the assumption is worth correcting. Because rows are keyed, scrolling already reuses the
+  overlap: scrolling by one row creates exactly one control and destroys one, moving the
+  rest. Churn is proportional to rows scrolled, not to window size — pinned by a test. A
+  WinUI `ItemsRepeater` would additionally reuse the container, saving that one
+  construction per scrolled row; worthwhile for sustained flings, but a micro-optimization
+  next to the thousands-to-a-viewport reduction that windowing already delivers.
+
+  It is also the expensive option: the diff emits patches for the whole list while only
+  some rows exist, so an `ItemsRepeater` design needs the interpreter to keep a shadow of
+  unrealized rows, and `INativeBackend` is now published so the capability would have to
+  be added as a separate optional interface. **Reclassified from a gap to a future
+  optimization**, to be revisited if profiling shows scroll construction actually hurting.
+- **Styling/theming ✅ done** ([ADR-029](../adr/ADR-029-native-theming-via-platform-brushes.md)).
+  Semantic roles (`ThemeColor.TextPrimary`, `SurfaceCard`, `Critical`, …) map onto WinUI's
+  own theme brushes, so light, dark and high-contrast follow the OS with no per-app work.
+  Additive: `INativeBackend` is unchanged, literal colours still work, and the value rides
+  as an ordinary string attribute. A key the platform does not define leaves the property
+  at its default and reports, rather than throwing.
+- **Accessibility — partially done.** `AutomationName`, `AutomationHelpText` and
+  `AccessibilityHidden` map onto `AutomationProperties`, which is what controls without
+  visible text need. Automation peers are known to work: the TaskTimer CI check drives
+  buttons through `IInvokeProvider`, the same tree a screen reader reads.
+
+  **Still open, and deliberately not claimed:** no audit against an actual screen reader.
+  These properties make correct names *possible*; they do not prove any given view is
+  usable. That audit needs a person with NVDA or Narrator, not more code.
 - **TaskTimer sample ✅ done.** The verification gap is closed. `Picea.Abies.TaskTimer.Native`
   exercises an interval subscription, subscriptions starting and stopping with the model,
   a keyed list that genuinely re-sorts, and two-way text input. `ABIES_INTERACT` drives it


### PR DESCRIPTION
Finishes Phase 3.

### What

- **Theming** — semantic `ThemeColor` roles mapped onto WinUI's own theme brushes ([ADR-029](https://github.com/Picea/Abies/blob/main/docs/adr/ADR-029-native-theming-via-platform-brushes.md))
- **Accessibility** — `AutomationName`, `AutomationHelpText`, `AccessibilityHidden`
- **Container recycling** — measured and reclassified rather than built
- A flaky test of mine, fixed

### Why

**Theming.** A literal colour is wrong in one of the two themes, which made the string-only API unusable in practice — an app styled for light mode is unreadable in dark.

```csharp
TextBlock([Foreground(ThemeColor.TextSecondary)], "Last updated 3m ago")
Border([Background(ThemeColor.SurfaceCard), BorderBrush(ThemeColor.Stroke)], content)
```

Light, dark **and high-contrast** follow the OS with no per-app work — a hand-rolled palette would miss the last one. The value rides as an ordinary `"theme:<key>"` string attribute, so nothing new was needed in the diff, the interpreter, or `INativeBackend` — which matters, since that interface is published and can't gain members without breaking.

A key the platform doesn't define **leaves the property at its default and reports** through `renderFaulted` rather than throwing. A missing brush is a styling problem, not a reason to lose a window.

**Accessibility.** Controls with visible text already expose it; these are for the ones that don't — icon-only buttons, unlabelled `TextBox`es. Automation peers are known to work: the TaskTimer CI check drives buttons through `IInvokeProvider`, the same tree a screen reader reads.

*Not claimed:* no audit against an actual screen reader. These properties make correct names **possible**; they don't prove any view is usable. Stated in both the guide and the plan — a half-done accessibility story that reads as finished is worse than one that's honest.

**Container recycling.** The plan called it "a project, not a patch". I measured before building, and the prize is much smaller than assumed. Rows are keyed, so scrolling already reuses the overlap — a new test asserts scrolling one row creates exactly **1** control, not a window's worth. Churn is proportional to rows *scrolled*, not window size.

An `ItemsRepeater` would additionally reuse the container, saving that single construction per scrolled row: worthwhile for sustained flings, a micro-optimization next to the thousands-to-a-viewport reduction already delivered, and expensive to do correctly (the diff patches rows that may not exist, so it needs a shadow tree plus a new optional interface). Recorded as a future optimization with the reasoning. I'd rather correct the plan's assumption than build the expensive thing it implied.

**The flaky test** was mine, from the error-boundary work: it waited a fixed `Task.Delay(50)` for a fault arriving on another thread. The Windows runner lost that bet. All three now wait on a `TaskCompletionSource` signalled by the code under test, so they synchronise on the work rather than the clock.

### Testing

**58 native tests** (9 new): theme encode/decode round-trips every role, literal colours stay literal, switching literal → theme updates in place without recreating controls, automation properties reach the control, removing a name resets it rather than leaving a stale announcement, and the scroll-reuse assertion.

Full solution build 0 errors; `dotnet format` clean; `DocSnippetCheck` 31 compiled / 0 failed.

Worth noting the Windows head caught the flake — the same job that has now found a formatting divergence, a dispatcher deadlock, and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)