### PR TITLE
chore(release): Bump version.json to 2.4

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.3"
+    "version": "2.4"
 }


### PR DESCRIPTION
### What

Bumps `version.json` from `2.3` to `2.4` ahead of tagging `v2.4.0`.

### Why

Two user-facing features since `v2.3.1`:

- **List windowing** (#352) — `Virtualization.Window`, `OnScrollChanged`, `VerticalOffset`. Control count follows the viewport instead of the data.
- **Theming and accessibility** (#353) — `ThemeColor` roles mapped to platform brushes, `AutomationName`/`AutomationHelpText`/`AccessibilityHidden`.

The other two commits are test-only fixes (the publish-probe race and a dispatch-fault flake) with no shipped behaviour change.

**Minor, not patch** — new public API, no source-breaking changes.

### One caveat

`WinUIBackend`'s constructor gained an optional callback:

```diff
- public WinUIBackend(Panel rootHost)
+ public WinUIBackend(Panel rootHost, Action<Exception>? brushFaulted = null)
```

**Source-compatible** (existing code compiles unchanged), **binary-breaking** (anything compiled against 2.3.x needs a recompile). Accepted because the package is days old with no meaningful installed base, and the alternative is carrying an awkward constructor indefinitely. Worth recording rather than discovering later.

### Testing

Version-only change. `main` is green — CD, CodeQL, Trivy, Semgrep and Secrets Scan all passing — and the release pipeline was proven end to end by `v2.3.1`, including the WinUI version-stamping fix and the filename assertion that now guards it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)